### PR TITLE
[buildbot] Implement Pollers

### DIFF
--- a/bb/master/config.py
+++ b/bb/master/config.py
@@ -54,7 +54,7 @@ POLL_INTERVAL = 10 # Poll Github for new changes (in seconds)
 
 WORKER_PASS = msdk_secrets.WORKER_PASS
 DATABASE_PASSWORD = msdk_secrets.DATABASE_PASSWORD
-DATABASE_URL = "postgresql://buildbot:%s@localhost/buildbot" % DATABASE_PASSWORD
+DATABASE_URL = f"postgresql://buildbot:{DATABASE_PASSWORD}@localhost/buildbot"
 GITHUB_TOKEN = msdk_secrets.GITHUB_TOKEN
 GITHUB_WEBHOOK_SECRET = msdk_secrets.GITHUB_WEBHOOK_SECRET
 GITHUB_OWNER = "Intel-Media-SDK"
@@ -71,8 +71,8 @@ elif CURRENT_MODE == Mode.TEST_MODE:
     GITHUB_OWNERS_REPO = "flow_test"
     BUILDBOT_URL = "http://mediasdk.intel.com/auxbb/"
 else:
-    sys.exit("Mode %s is not defined" % CURRENT_MODE)
+    sys.exit(f"Mode {CURRENT_MODE} is not defined")
 
-GITHUB_REPOSITORY = "%s/%s" GITHUB_OWNER, GITHUB_OWNERS_REPO
-REPO_URL = "https://github.com/%s" % GITHUB_REPOSITORY
-REPO_INFO = "%s:%(prop:branch)s:%(prop:revision)s" % GITHUB_OWNERS_REPO
+GITHUB_REPOSITORY = f"{GITHUB_OWNER}/{GITHUB_OWNERS_REPO}"
+REPO_URL = f"https://github.com/{GITHUB_REPOSITORY}"
+REPO_INFO = f"{GITHUB_OWNERS_REPO}:%(prop:branch)s:%(prop:revision)s"

--- a/bb/master/config.py
+++ b/bb/master/config.py
@@ -28,7 +28,6 @@ class Mode(Enum):
     PRODUCTION_MODE = "production_mode"
     TEST_MODE = "test_mode"
 
-
 BUILD = "build"
 BUILD_MASTER = "build-master-branch"
 BUILD_NOT_MASTER = "build-other-branches"
@@ -36,9 +35,6 @@ BUILD_API_LATEST = "build-api-latest"
 
 TEST = "test"
 TEST_API_LATEST = "test-api-latest"
-
-WORKER_PASS = msdk_secrets.WORKER_PASS
-DATABASE_PASSWORD = msdk_secrets.DATABASE_PASSWORD
 
 RUN_COMMAND = "python3.6"
 WORKERS = {BUILD: {"b-1-10": {},
@@ -54,26 +50,29 @@ BUILDBOT_NET_USAGE_DATA = None # "None" disables the sending of usage analysis i
 BUILDBOT_TREE_STABLE_TIMER = None # Value "None" means that a separate build will be started immediately for each Change.
 BUILDBOT_TITLE = "Intel® Media SDK"
 
+POLL_INTERVAL = 10 # Poll Github for new changes (in seconds)
+
+WORKER_PASS = msdk_secrets.WORKER_PASS
+DATABASE_PASSWORD = msdk_secrets.DATABASE_PASSWORD
+DATABASE_URL = "postgresql://buildbot:%s@localhost/buildbot" % DATABASE_PASSWORD
 GITHUB_TOKEN = msdk_secrets.GITHUB_TOKEN
 GITHUB_WEBHOOK_SECRET = msdk_secrets.GITHUB_WEBHOOK_SECRET
+GITHUB_OWNER = "Intel-Media-SDK"
 
 CURRENT_MODE = Mode.PRODUCTION_MODE
 #CURRENT_MODE = Mode.TEST_MODE
 
 if CURRENT_MODE == Mode.PRODUCTION_MODE:
-    DATABASE_URL = "postgresql://buildbot:%s@localhost/buildbot" % DATABASE_PASSWORD
-    GITHUB_REPOSITORY = "Intel-Media-SDK/MediaSDK"
-    BUILDBOT_TITLE_URL = "https://github.com/Intel-Media-SDK/MediaSDK"
-    REPO_INFO = r"MediaSDK:%(prop:branch)s:%(prop:revision)s"
-
+    GITHUB_OWNERS_REPO = "MediaSDK"
     BUILDBOT_URL = "http://mediasdk.intel.com/buildbot/"
 
 elif CURRENT_MODE == Mode.TEST_MODE:
-    DATABASE_URL = "postgresql://buildbot:%s@localhost/buildbot" % DATABASE_PASSWORD
-    GITHUB_REPOSITORY = "Intel-Media-SDK/flow_test"
-    BUILDBOT_TITLE_URL = "https://github.com/Intel-Media-SDK/flow_test"
-    REPO_INFO = r"flow_test:%(prop:branch)s:%(prop:revision)s"
-
+    DATABASE_URL = "sqlite:///state.sqlite" # Only for test mode
+    GITHUB_OWNERS_REPO = "flow_test"
     BUILDBOT_URL = "http://mediasdk.intel.com/auxbb/"
 else:
     sys.exit("Mode %s is not defined" % CURRENT_MODE)
+
+GITHUB_REPOSITORY = "%s/%s" GITHUB_OWNER, GITHUB_OWNERS_REPO
+REPO_URL = "https://github.com/%s" % GITHUB_REPOSITORY
+REPO_INFO = "%s:%(prop:branch)s:%(prop:revision)s" % GITHUB_OWNERS_REPO

--- a/bb/master/master.cfg
+++ b/bb/master/master.cfg
@@ -187,7 +187,7 @@ def pr_filter(pr):
 #    pollAtLaunch = True))
 
 c["change_source"].append(GitPoller(
-    repourl = "%s.git" % REPO_URL,
+    repourl = f"{REPO_URL}.git",
     workdir = "gitpoller-workdir", # Dir for the output of git remote-ls command
     branches = True, # Poll all branches
     category = "mediasdk",

--- a/bb/master/master.cfg
+++ b/bb/master/master.cfg
@@ -106,18 +106,18 @@ c["buildbotURL"] = config.BUILDBOT_URL
 # Schedulers
 c["schedulers"] = [
     schedulers.SingleBranchScheduler(name=config.BUILD_MASTER,
-                                     change_filter=util.ChangeFilter(project=config.GITHUB_REPOSITORY, branch="master"),
-                                     #change_filter=util.ChangeFilter(category = "mediasdk", branch="master"),
+                                     #change_filter=util.ChangeFilter(project=config.GITHUB_REPOSITORY, branch="master"),
+                                     change_filter=util.ChangeFilter(category = "mediasdk", branch="master"),
                                      treeStableTimer=config.BUILDBOT_TREE_STABLE_TIMER,
                                      builderNames=[config.BUILD_MASTER]),
     schedulers.SingleBranchScheduler(name=config.BUILD_NOT_MASTER,
-                                     change_filter=util.ChangeFilter(project=config.GITHUB_REPOSITORY, branch_re="(?!master)"),
-                                     #change_filter=util.ChangeFilter(category = "mediasdk", branch_re="(?!master)"),
+                                     #change_filter=util.ChangeFilter(project=config.GITHUB_REPOSITORY, branch_re="(?!master)"),
+                                     change_filter=util.ChangeFilter(category = "mediasdk", branch_re="(?!master)"),
                                      treeStableTimer=config.BUILDBOT_TREE_STABLE_TIMER,
                                      builderNames=[config.BUILD_NOT_MASTER]),
     schedulers.SingleBranchScheduler(name=config.BUILD_API_LATEST,
-                                     change_filter=util.ChangeFilter(project=config.GITHUB_REPOSITORY, branch_re=".+?"),
-                                     #change_filter=util.ChangeFilter(category = "mediasdk", branch_re=".+?"),
+                                     #change_filter=util.ChangeFilter(project=config.GITHUB_REPOSITORY, branch_re=".+?"),
+                                     change_filter=util.ChangeFilter(category = "mediasdk", branch_re=".+?"),
                                      treeStableTimer=config.BUILDBOT_TREE_STABLE_TIMER,
                                      builderNames=[config.BUILD_API_LATEST]),
     schedulers.Triggerable(name=config.TEST,
@@ -173,23 +173,31 @@ c["services"] = [
 c['change_source'] = []
 
 
+def pr_filter(pr):
+    # Include only changes from fork repositories
+    if pr['head']['repo']['full_name'] != "Intel-Media-SDK/flow_test": #TODO: hard-coded 
+        return False
+    return True
+
+
 c['change_source'].append(GitHubPullrequestPoller(
     owner = "Intel-Media-SDK",
     repo = "flow_test",
     token = config.GITHUB_TOKEN,
     pollInterval = 10,  # Check PRs every 10 seconds
-    #category = "mediasdk",
-    project=config.GITHUB_REPOSITORY,
+    pullrequest_filter = pr_filter,
+    category = "mediasdk", #TODO: hard-coded 
+    #project=config.GITHUB_REPOSITORY,
     pollAtLaunch = True))
 
 #poll only master?!
 c['change_source'].append(GitPoller(
     repourl = "git@github.com:Intel-Media-SDK/flow_test.git",
     workdir = "gitpoller-workdir", #tmp
-    branches = "master", #all branches?
+    branch = "master", #???
     #branches = True, #all branches?
-    #category = "mediasdk",
-    project=config.GITHUB_REPOSITORY,
+    category = "mediasdk", #TODO: hard-coded 
+    #project=config.GITHUB_REPOSITORY,
     pollInterval = 10,
     pollAtLaunch = True))
 

--- a/bb/master/master.cfg
+++ b/bb/master/master.cfg
@@ -99,24 +99,21 @@ c["protocols"] = {"pb": {"port": config.WORKER_PORT}}
 # Basic config
 c["buildbotNetUsageData"] = config.BUILDBOT_NET_USAGE_DATA
 c["title"] = config.BUILDBOT_TITLE
-c["titleURL"] = config.BUILDBOT_TITLE_URL
+c["titleURL"] = config.REPO_URL
 c["buildbotURL"] = config.BUILDBOT_URL
 
 
 # Schedulers
 c["schedulers"] = [
     schedulers.SingleBranchScheduler(name=config.BUILD_MASTER,
-                                     #change_filter=util.ChangeFilter(project=config.GITHUB_REPOSITORY, branch="master"),
                                      change_filter=util.ChangeFilter(category="mediasdk", branch="master"),
                                      treeStableTimer=config.BUILDBOT_TREE_STABLE_TIMER,
                                      builderNames=[config.BUILD_MASTER]),
     schedulers.SingleBranchScheduler(name=config.BUILD_NOT_MASTER,
-                                     #change_filter=util.ChangeFilter(project=config.GITHUB_REPOSITORY, branch_re="(?!master)"),
                                      change_filter=util.ChangeFilter(category="mediasdk", branch_re="(?!master)"),
                                      treeStableTimer=config.BUILDBOT_TREE_STABLE_TIMER,
                                      builderNames=[config.BUILD_NOT_MASTER]),
     schedulers.SingleBranchScheduler(name=config.BUILD_API_LATEST,
-                                     #change_filter=util.ChangeFilter(project=config.GITHUB_REPOSITORY, branch_re=".+?"),
                                      change_filter=util.ChangeFilter(category="mediasdk", branch_re=".+?"),
                                      treeStableTimer=config.BUILDBOT_TREE_STABLE_TIMER,
                                      builderNames=[config.BUILD_API_LATEST]),
@@ -170,30 +167,31 @@ c["services"] = [
 #                                 verbose=True,
 #                                 debug=True)]
 
-c['change_source'] = []
+c["change_source"] = []
 
 def pr_filter(pr):
     # Include only changes from fork repositories
-    if pr['head']['repo']['full_name'] == "Intel-Media-SDK/flow_test": #TODO: hard-coded  + should be changeable in mode!
+    if pr["head"]["repo"]["full_name"] == config.GITHUB_REPOSITORY:
         return False
     return True
 
-# To process only the changes from forked repositories
-c['change_source'].append(GitHubPullrequestPoller(
-    owner = "Intel-Media-SDK",
-    repo = "flow_test",
-    token = config.GITHUB_TOKEN,
-    pollInterval = 10, # Check PRs every 10 seconds #TODO: hard-coded!
-    pullrequest_filter = pr_filter,
-    category = "mediasdk", #TODO: hard-coded
-    pollAtLaunch = True))
+# TODO: Need to fix MDP-38719 to enable this feature
+## To process only the changes from forked repositories
+#c["change_source"].append(GitHubPullrequestPoller(
+#    owner = config.GITHUB_OWNER,
+#    repo = config.GITHUB_OWNERS_REPO,
+#    token = config.GITHUB_TOKEN,
+#    pullrequest_filter = pr_filter,
+#    category = "mediasdk",
+#    pollInterval = config.POLL_INTERVAL, # Interval of PR`s checking
+#    pollAtLaunch = True))
 
-c['change_source'].append(GitPoller(
-    repourl = "git@github.com:Intel-Media-SDK/flow_test.git",
-    workdir = "gitpoller-workdir", #tmp
-    branches = True, # poll all branches
-    category = "mediasdk", #TODO: hard-coded 
-    pollInterval = 10,
+c["change_source"].append(GitPoller(
+    repourl = "%s.git" % REPO_URL,
+    workdir = "gitpoller-workdir", # Dir for the output of git remote-ls command
+    branches = True, # Poll all branches
+    category = "mediasdk",
+    pollInterval = config.POLL_INTERVAL,
     pollAtLaunch = True))
 
 
@@ -209,6 +207,7 @@ c["db"] = {"db_url": config.DATABASE_URL}
 c["collapseRequests"] = False # It disables automatic merging of requests
                               # (to build EACH commit)
 
+# Disabled because there is GitPoller implementation
 ## GitHub webhook receiver
 #c["www"]["change_hook_dialects"] = {
 #        "github": {

--- a/bb/master/master.cfg
+++ b/bb/master/master.cfg
@@ -206,12 +206,3 @@ c["db"] = {"db_url": config.DATABASE_URL}
 
 c["collapseRequests"] = False # It disables automatic merging of requests
                               # (to build EACH commit)
-
-# Disabled because there is GitPoller implementation
-## GitHub webhook receiver
-#c["www"]["change_hook_dialects"] = {
-#        "github": {
-#                "secret": config.GITHUB_WEBHOOK_SECRET,
-#                "strict": True,
-#        }
-#}

--- a/bb/master/master.cfg
+++ b/bb/master/master.cfg
@@ -107,14 +107,17 @@ c["buildbotURL"] = config.BUILDBOT_URL
 c["schedulers"] = [
     schedulers.SingleBranchScheduler(name=config.BUILD_MASTER,
                                      change_filter=util.ChangeFilter(project=config.GITHUB_REPOSITORY, branch="master"),
+                                     #change_filter=util.ChangeFilter(category = "mediasdk", branch="master"),
                                      treeStableTimer=config.BUILDBOT_TREE_STABLE_TIMER,
                                      builderNames=[config.BUILD_MASTER]),
     schedulers.SingleBranchScheduler(name=config.BUILD_NOT_MASTER,
                                      change_filter=util.ChangeFilter(project=config.GITHUB_REPOSITORY, branch_re="(?!master)"),
+                                     #change_filter=util.ChangeFilter(category = "mediasdk", branch_re="(?!master)"),
                                      treeStableTimer=config.BUILDBOT_TREE_STABLE_TIMER,
                                      builderNames=[config.BUILD_NOT_MASTER]),
     schedulers.SingleBranchScheduler(name=config.BUILD_API_LATEST,
                                      change_filter=util.ChangeFilter(project=config.GITHUB_REPOSITORY, branch_re=".+?"),
+                                     #change_filter=util.ChangeFilter(category = "mediasdk", branch_re=".+?"),
                                      treeStableTimer=config.BUILDBOT_TREE_STABLE_TIMER,
                                      builderNames=[config.BUILD_API_LATEST]),
     schedulers.Triggerable(name=config.TEST,
@@ -167,15 +170,29 @@ c["services"] = [
 #                                 verbose=True,
 #                                 debug=True)]
 
+c['change_source'] = []
+
+
 c['change_source'].append(GitHubPullrequestPoller(
-    owner = 'adydychk', #What about MediaSDK? Faceless?
-    repo = 'flow_test',
+    owner = "Intel-Media-SDK",
+    repo = "flow_test",
     token = config.GITHUB_TOKEN,
-    #pullrequest_filter = pr_filter,
-    #pollInterval = 60*5,  # Check PRs every 5 minutes
-    pollInterval = 5,  # 5 seconds
+    pollInterval = 10,  # Check PRs every 10 seconds
+    #category = "mediasdk",
+    project=config.GITHUB_REPOSITORY,
     pollAtLaunch = True))
-    #category= ?
+
+#poll only master?!
+c['change_source'].append(GitPoller(
+    repourl = "git@github.com:Intel-Media-SDK/flow_test.git",
+    workdir = "gitpoller-workdir", #tmp
+    branches = "master", #all branches?
+    #branches = True, #all branches?
+    #category = "mediasdk",
+    project=config.GITHUB_REPOSITORY,
+    pollInterval = 10,
+    pollAtLaunch = True))
+
 
 # Web Interface
 c["www"] = dict(port=int(config.PORT),
@@ -189,10 +206,10 @@ c["db"] = {"db_url": config.DATABASE_URL}
 c["collapseRequests"] = False # It disables automatic merging of requests
                               # (to build EACH commit)
 
-# GitHub webhook receiver
-c["www"]["change_hook_dialects"] = {
-        "github": {
-                "secret": config.GITHUB_WEBHOOK_SECRET,
-                "strict": True,
-        }
-}
+## GitHub webhook receiver
+#c["www"]["change_hook_dialects"] = {
+#        "github": {
+#                "secret": config.GITHUB_WEBHOOK_SECRET,
+#                "strict": True,
+#        }
+#}

--- a/bb/master/master.cfg
+++ b/bb/master/master.cfg
@@ -24,6 +24,8 @@
 from enum import Enum
 import re
 
+from buildbot.changes.gitpoller import GitPoller
+from buildbot.changes.github import GitHubPullrequestPoller
 from buildbot.plugins import schedulers, changes, util, steps, worker, reporters
 import config
 
@@ -164,6 +166,16 @@ c["services"] = [
 #                                 endDescription="Done (comment)",
 #                                 verbose=True,
 #                                 debug=True)]
+
+c['change_source'].append(GitHubPullrequestPoller(
+    owner = 'adydychk', #What about MediaSDK? Faceless?
+    repo = 'flow_test',
+    token = config.GITHUB_TOKEN,
+    #pullrequest_filter = pr_filter,
+    #pollInterval = 60*5,  # Check PRs every 5 minutes
+    pollInterval = 5,  # 5 seconds
+    pollAtLaunch = True))
+    #category= ?
 
 # Web Interface
 c["www"] = dict(port=int(config.PORT),

--- a/bb/master/master.cfg
+++ b/bb/master/master.cfg
@@ -107,17 +107,17 @@ c["buildbotURL"] = config.BUILDBOT_URL
 c["schedulers"] = [
     schedulers.SingleBranchScheduler(name=config.BUILD_MASTER,
                                      #change_filter=util.ChangeFilter(project=config.GITHUB_REPOSITORY, branch="master"),
-                                     change_filter=util.ChangeFilter(category = "mediasdk", branch="master"),
+                                     change_filter=util.ChangeFilter(category="mediasdk", branch="master"),
                                      treeStableTimer=config.BUILDBOT_TREE_STABLE_TIMER,
                                      builderNames=[config.BUILD_MASTER]),
     schedulers.SingleBranchScheduler(name=config.BUILD_NOT_MASTER,
                                      #change_filter=util.ChangeFilter(project=config.GITHUB_REPOSITORY, branch_re="(?!master)"),
-                                     change_filter=util.ChangeFilter(category = "mediasdk", branch_re="(?!master)"),
+                                     change_filter=util.ChangeFilter(category="mediasdk", branch_re="(?!master)"),
                                      treeStableTimer=config.BUILDBOT_TREE_STABLE_TIMER,
                                      builderNames=[config.BUILD_NOT_MASTER]),
     schedulers.SingleBranchScheduler(name=config.BUILD_API_LATEST,
                                      #change_filter=util.ChangeFilter(project=config.GITHUB_REPOSITORY, branch_re=".+?"),
-                                     change_filter=util.ChangeFilter(category = "mediasdk", branch_re=".+?"),
+                                     change_filter=util.ChangeFilter(category="mediasdk", branch_re=".+?"),
                                      treeStableTimer=config.BUILDBOT_TREE_STABLE_TIMER,
                                      builderNames=[config.BUILD_API_LATEST]),
     schedulers.Triggerable(name=config.TEST,
@@ -172,32 +172,27 @@ c["services"] = [
 
 c['change_source'] = []
 
-
 def pr_filter(pr):
     # Include only changes from fork repositories
-    if pr['head']['repo']['full_name'] != "Intel-Media-SDK/flow_test": #TODO: hard-coded 
+    if pr['head']['repo']['full_name'] == "Intel-Media-SDK/flow_test": #TODO: hard-coded  + should be changeable in mode!
         return False
     return True
 
-
+# To process only the changes from forked repositories
 c['change_source'].append(GitHubPullrequestPoller(
     owner = "Intel-Media-SDK",
     repo = "flow_test",
     token = config.GITHUB_TOKEN,
-    pollInterval = 10,  # Check PRs every 10 seconds
+    pollInterval = 10, # Check PRs every 10 seconds #TODO: hard-coded!
     pullrequest_filter = pr_filter,
-    category = "mediasdk", #TODO: hard-coded 
-    #project=config.GITHUB_REPOSITORY,
+    category = "mediasdk", #TODO: hard-coded
     pollAtLaunch = True))
 
-#poll only master?!
 c['change_source'].append(GitPoller(
     repourl = "git@github.com:Intel-Media-SDK/flow_test.git",
     workdir = "gitpoller-workdir", #tmp
-    branch = "master", #???
-    #branches = True, #all branches?
+    branches = True, # poll all branches
     category = "mediasdk", #TODO: hard-coded 
-    #project=config.GITHUB_REPOSITORY,
     pollInterval = 10,
     pollAtLaunch = True))
 

--- a/bb/master/msdk_secrets.py.example
+++ b/bb/master/msdk_secrets.py.example
@@ -1,4 +1,4 @@
-# Copyright (c) 2017 Intel Corporation
+# Copyright (c) 2018 Intel Corporation
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -22,4 +22,3 @@ WORKER_PASS = "my_password"
 DATABASE_PASSWORD = "my_password"
 
 GITHUB_TOKEN = "my_token"
-GITHUB_WEBHOOK_SECRET = "my_password"


### PR DESCRIPTION
- Implemented Pollers:
    - `GitPoller`
    - `GithubPullRequestPoller` - implemented but **disabled** because need support on the side of `build_scripts`
- GitHub webhook receiver removed (full alternative is `GitPoller`)
- Some minor changes in config.py to improve readability
  
Pollers are tested for the stable work **in** and **out** of the Intel`s infrastructure.

P.S.  
To enable GitHub webhook need to:
- Add `c["www"]["change_hook_dialects"] = ...`
- Add `project=config.GITHUB_REPOSITORY` instead of `category` in `ChangeFilter`
- Add `GITHUB_WEBHOOK_SECRET = "my_password"` in `msdk_secrets.py.example`