### PR TITLE
Add CI for Pull Requests from forked repositories

### DIFF
--- a/bb/master/config.py
+++ b/bb/master/config.py
@@ -78,7 +78,6 @@ elif CURRENT_MODE == Mode.PRODUCTION_MODE_PRIVATE:
     MASTER_PRODUCT_TYPE = "embedded_private"
 
 elif CURRENT_MODE == Mode.TEST_MODE:
-    DATABASE_URL = "sqlite:///state.sqlite" # Only for test mode
     GITHUB_OWNERS_REPO = "flow_test"
     BUILDBOT_URL = "http://mediasdk.intel.com/auxbb/"
 else:

--- a/bb/master/master.cfg
+++ b/bb/master/master.cfg
@@ -54,6 +54,7 @@ def init_build_factory(conf_file="conf_open_source.py",
                                         "--build-type", config.BUILD_TYPE,
                                         "--build-event", "commit",
                                         "--product-type", product_type,
+                                        "--fork-url", util.Interpolate(r"%(prop:repository)s"),
                                         "--stage", stage.value],
                                workdir=r"../infrastructure/build_scripts",
                                name=stage.value))
@@ -175,16 +176,15 @@ def pull_request_filter(pr):
         return False
     return True
 
-# TODO: Need to fix MDP-38719 to enable this feature
-## To process only the changes from forked repositories
-#c["change_source"].append(GitHubPullrequestPoller(
-#    owner = config.GITHUB_OWNER,
-#    repo = config.GITHUB_OWNERS_REPO,
-#    token = config.GITHUB_TOKEN,
-#    pullrequest_filter = pull_request_filter,
-#    category = "mediasdk",
-#    pollInterval = config.POLL_INTERVAL, # Interval of PR`s checking
-#    pollAtLaunch = True))
+# To process only the changes from forked repositories
+c["change_source"].append(GitHubPullrequestPoller(
+    owner = config.GITHUB_OWNER,
+    repo = config.GITHUB_OWNERS_REPO,
+    token = config.GITHUB_TOKEN,
+    pullrequest_filter = pull_request_filter,
+    category = "mediasdk",
+    pollInterval = config.POLL_INTERVAL, # Interval of PR`s checking
+    pollAtLaunch = True))
 
 c["change_source"].append(GitPoller(
     repourl = f"{config.REPO_URL}.git",

--- a/bb/master/master.cfg
+++ b/bb/master/master.cfg
@@ -37,27 +37,48 @@ class Stage(Enum): #TODO: use shared module?
     PACK = "pack"
     COPY = "copy"
 
+@util.renderer
+def is_product_repository(props):
+    return props.get("repository") == config.REPO_URL
+
 
 def init_build_factory(conf_file="conf_open_source.py",
                        product_type=config.MASTER_PRODUCT_TYPE):
     build_factory = util.BuildFactory()
     #Build by stages: clean, extract, build, install, pack, copy
-    for stage in Stage:
-        build_factory.addStep(
-            steps.ShellCommand(command=[config.RUN_COMMAND,
-                                        "build_runner.py",
-                                        "--build-config",
-                                            util.Interpolate(r"%(prop:builddir)s/../product-configs/%(kw:conf_file)s",
-                                                conf_file=conf_file),
-                                        "--root-dir", util.Interpolate(r"%(prop:builddir)s/build_dir"),
-                                        "--changed-repo", util.Interpolate(config.REPO_INFO),
-                                        "--build-type", config.BUILD_TYPE,
-                                        "--build-event", "commit",
-                                        "--product-type", product_type,
-                                        "--fork-url", util.Interpolate(r"%(prop:repository)s"),
-                                        "--stage", stage.value],
-                               workdir=r"../infrastructure/build_scripts",
-                               name=stage.value))
+    if is_product_repository:
+        for stage in Stage:
+            build_factory.addStep(
+                steps.ShellCommand(command=[config.RUN_COMMAND,
+                                            "build_runner.py",
+                                            "--build-config",
+                                                util.Interpolate(r"%(prop:builddir)s/../product-configs/%(kw:conf_file)s",
+                                                    conf_file=conf_file),
+                                            "--root-dir", util.Interpolate(r"%(prop:builddir)s/build_dir"),
+                                            "--changed-repo", util.Interpolate(config.REPO_INFO),
+                                            "--build-type", config.BUILD_TYPE,
+                                            "--build-event", "commit",
+                                            "--product-type", product_type,
+                                            "--stage", stage.value],
+                                   workdir=r"../infrastructure/build_scripts",
+                                   name=stage.value))
+    else:
+        for stage in Stage:
+            build_factory.addStep(
+                steps.ShellCommand(command=[config.RUN_COMMAND,
+                                            "build_runner.py",
+                                            "--build-config",
+                                                util.Interpolate(r"%(prop:builddir)s/../product-configs/%(kw:conf_file)s",
+                                                    conf_file=conf_file),
+                                            "--root-dir", util.Interpolate(r"%(prop:builddir)s/build_dir"),
+                                            "--changed-repo", util.Interpolate(config.REPO_INFO),
+                                            "--build-type", config.BUILD_TYPE,
+                                            "--build-event", "commit",
+                                            "--product-type", product_type,
+                                            "--fork-url", util.Interpolate(r"%(prop:repository)s"),
+                                            "--stage", stage.value],
+                                   workdir=r"../infrastructure/build_scripts",
+                                   name=stage.value))
 
     #Trigger tests
     if product_type == config.MASTER_PRODUCT_TYPE:

--- a/bb/master/master.cfg
+++ b/bb/master/master.cfg
@@ -53,7 +53,7 @@ def init_build_factory(conf_file="conf_open_source.py",
                                         "--build-type", config.BUILD_TYPE,
                                         "--build-event", "commit",
                                         "--product-type", product_type,
-                                        "--fork-url", util.Interpolate(r"%(prop:repository)s"),
+                                        "--repo-url", util.Interpolate(r"%(prop:repository)s"),
                                         "--stage", stage.value],
                                workdir=r"../infrastructure/build_scripts",
                                name=stage.value))

--- a/bb/master/master.cfg
+++ b/bb/master/master.cfg
@@ -39,46 +39,29 @@ class Stage(Enum): #TODO: use shared module?
 
 @util.renderer
 def is_product_repository(props):
-    return props.get("repository") == config.REPO_URL
-
+    if props.get("repository") == f"{config.REPO_URL}.git"
+        return ["--fork-url", props.get("repository")]
+    return []
 
 def init_build_factory(conf_file="conf_open_source.py",
                        product_type=config.MASTER_PRODUCT_TYPE):
     build_factory = util.BuildFactory()
     #Build by stages: clean, extract, build, install, pack, copy
-    if is_product_repository:
-        for stage in Stage:
-            build_factory.addStep(
-                steps.ShellCommand(command=[config.RUN_COMMAND,
-                                            "build_runner.py",
-                                            "--build-config",
-                                                util.Interpolate(r"%(prop:builddir)s/../product-configs/%(kw:conf_file)s",
-                                                    conf_file=conf_file),
-                                            "--root-dir", util.Interpolate(r"%(prop:builddir)s/build_dir"),
-                                            "--changed-repo", util.Interpolate(config.REPO_INFO),
-                                            "--build-type", config.BUILD_TYPE,
-                                            "--build-event", "commit",
-                                            "--product-type", product_type,
-                                            "--stage", stage.value],
-                                   workdir=r"../infrastructure/build_scripts",
-                                   name=stage.value))
-    else:
-        for stage in Stage:
-            build_factory.addStep(
-                steps.ShellCommand(command=[config.RUN_COMMAND,
-                                            "build_runner.py",
-                                            "--build-config",
-                                                util.Interpolate(r"%(prop:builddir)s/../product-configs/%(kw:conf_file)s",
-                                                    conf_file=conf_file),
-                                            "--root-dir", util.Interpolate(r"%(prop:builddir)s/build_dir"),
-                                            "--changed-repo", util.Interpolate(config.REPO_INFO),
-                                            "--build-type", config.BUILD_TYPE,
-                                            "--build-event", "commit",
-                                            "--product-type", product_type,
-                                            "--fork-url", util.Interpolate(r"%(prop:repository)s"),
-                                            "--stage", stage.value],
-                                   workdir=r"../infrastructure/build_scripts",
-                                   name=stage.value))
+    for stage in Stage:
+        build_factory.addStep(
+            steps.ShellCommand(command=[config.RUN_COMMAND,
+                                        "build_runner.py",
+                                        "--build-config",
+                                            util.Interpolate(r"%(prop:builddir)s/../product-configs/%(kw:conf_file)s",
+                                                conf_file=conf_file),
+                                        "--root-dir", util.Interpolate(r"%(prop:builddir)s/build_dir"),
+                                        "--changed-repo", util.Interpolate(config.REPO_INFO),
+                                        "--build-type", config.BUILD_TYPE,
+                                        "--build-event", "commit",
+                                        "--product-type", product_type,
+                                        "--stage", stage.value] + is_product_repository,
+                               workdir=r"../infrastructure/build_scripts",
+                               name=stage.value))
 
     #Trigger tests
     if product_type == config.MASTER_PRODUCT_TYPE:

--- a/bb/master/master.cfg
+++ b/bb/master/master.cfg
@@ -37,33 +37,24 @@ class Stage(Enum): #TODO: use shared module?
     PACK = "pack"
     COPY = "copy"
 
-@util.renderer
-def generate_command(props):
-    print(props)
-    print(props.build.currentStep)
-    command=[config.RUN_COMMAND,
-            "build_runner.py",
-            "--build-config",
-                util.Interpolate(r"%(prop:builddir)s/../product-configs/%(kw:conf_file)s",
-                    conf_file=conf_file),
-            "--root-dir", util.Interpolate(r"%(prop:builddir)s/build_dir"),
-            "--changed-repo", util.Interpolate(config.REPO_INFO),
-            "--build-type", config.BUILD_TYPE,
-            "--build-event", "commit",
-            "--product-type", product_type,
-            "--stage", stage.value]
-
-    if props.get("repository") == f"{config.REPO_URL}.git":
-        return command
-    return command + ["--fork-url", props.get("repository")]
-
 def init_build_factory(conf_file="conf_open_source.py",
                        product_type=config.MASTER_PRODUCT_TYPE):
     build_factory = util.BuildFactory()
     #Build by stages: clean, extract, build, install, pack, copy
     for stage in Stage:
         build_factory.addStep(
-            steps.ShellCommand(command=generate_command,
+            steps.ShellCommand(command=[config.RUN_COMMAND,
+                                        "build_runner.py",
+                                        "--build-config",
+                                            util.Interpolate(r"%(prop:builddir)s/../product-configs/%(kw:conf_file)s",
+                                                conf_file=conf_file),
+                                        "--root-dir", util.Interpolate(r"%(prop:builddir)s/build_dir"),
+                                        "--changed-repo", util.Interpolate(config.REPO_INFO),
+                                        "--build-type", config.BUILD_TYPE,
+                                        "--build-event", "commit",
+                                        "--product-type", product_type,
+                                        "--fork-url", util.Interpolate(r"%(prop:repository)s"),
+                                        "--stage", stage.value],
                                workdir=r"../infrastructure/build_scripts",
                                name=stage.value))
 

--- a/bb/master/master.cfg
+++ b/bb/master/master.cfg
@@ -38,10 +38,24 @@ class Stage(Enum): #TODO: use shared module?
     COPY = "copy"
 
 @util.renderer
-def is_product_repository(props):
-    if props.get("repository") == f"{config.REPO_URL}.git"
-        return ["--fork-url", props.get("repository")]
-    return []
+def generate_command(props):
+    print(props)
+    print(props.build.currentStep)
+    command=[config.RUN_COMMAND,
+            "build_runner.py",
+            "--build-config",
+                util.Interpolate(r"%(prop:builddir)s/../product-configs/%(kw:conf_file)s",
+                    conf_file=conf_file),
+            "--root-dir", util.Interpolate(r"%(prop:builddir)s/build_dir"),
+            "--changed-repo", util.Interpolate(config.REPO_INFO),
+            "--build-type", config.BUILD_TYPE,
+            "--build-event", "commit",
+            "--product-type", product_type,
+            "--stage", stage.value]
+
+    if props.get("repository") == f"{config.REPO_URL}.git":
+        return command
+    return command + ["--fork-url", props.get("repository")]
 
 def init_build_factory(conf_file="conf_open_source.py",
                        product_type=config.MASTER_PRODUCT_TYPE):
@@ -49,17 +63,7 @@ def init_build_factory(conf_file="conf_open_source.py",
     #Build by stages: clean, extract, build, install, pack, copy
     for stage in Stage:
         build_factory.addStep(
-            steps.ShellCommand(command=[config.RUN_COMMAND,
-                                        "build_runner.py",
-                                        "--build-config",
-                                            util.Interpolate(r"%(prop:builddir)s/../product-configs/%(kw:conf_file)s",
-                                                conf_file=conf_file),
-                                        "--root-dir", util.Interpolate(r"%(prop:builddir)s/build_dir"),
-                                        "--changed-repo", util.Interpolate(config.REPO_INFO),
-                                        "--build-type", config.BUILD_TYPE,
-                                        "--build-event", "commit",
-                                        "--product-type", product_type,
-                                        "--stage", stage.value] + is_product_repository,
+            steps.ShellCommand(command=generate_command,
                                workdir=r"../infrastructure/build_scripts",
                                name=stage.value))
 

--- a/build_scripts/build_runner.py
+++ b/build_scripts/build_runner.py
@@ -377,7 +377,7 @@ class BuildGenerator(object):
         self.log = logging.getLogger()
 
         # Build and extract in directory for forked repositories in case of commit from forked repository
-        if fork_url == f"{MediaSdkDirectories.get_repo_url_by_name(self.default_options["REPO_NAME"])}.git":
+        if fork_url != f"{MediaSdkDirectories.get_repo_url_by_name(self.default_options['REPO_NAME'])}.git":
             self.default_options["REPOS_DIR"] = self.default_options["REPOS_FORKED_DIR"]
 
     def generate_build_config(self):

--- a/build_scripts/build_runner.py
+++ b/build_scripts/build_runner.py
@@ -377,7 +377,7 @@ class BuildGenerator(object):
         self.log = logging.getLogger()
 
         # Build and extract in directory for forked repositories in case of commit from forked repository
-        if fork_url:
+        if fork_url == f"{MediaSdkDirectories.get_repo_url_by_name(self.default_options["REPO_NAME"])}.git":
             self.default_options["REPOS_DIR"] = self.default_options["REPOS_FORKED_DIR"]
 
     def generate_build_config(self):

--- a/build_scripts/build_runner.py
+++ b/build_scripts/build_runner.py
@@ -322,7 +322,7 @@ class BuildGenerator(object):
     """
 
     def __init__(self, build_config_path, root_dir, build_type, product_type, build_event,
-                 commit_time=None, changed_repo=None, fork_url=None):
+                 commit_time=None, changed_repo=None, repo_url=None):
         """
         :param build_config_path: Path to build configuration file
         :type build_config_path: pathlib.Path
@@ -345,8 +345,8 @@ class BuildGenerator(object):
         :param changed_repo: Information about changed source repository
         :type changed_repo: String
         
-        :param fork_url: Link to forked repository
-        :type fork_url: String
+        :param repo_url: Link to the external repository (repository which is not in mediasdk_directories)
+        :type repo_url: String
         """
 
         self.build_config_path = build_config_path
@@ -356,7 +356,7 @@ class BuildGenerator(object):
         self.build_event = build_event
         self.commit_time = commit_time
         self.changed_repo = changed_repo
-        self.fork_url = fork_url
+        self.repo_url = repo_url
         self.build_state_file = root_dir / "build_state"
         self.default_options = {
             "ROOT_DIR": root_dir,
@@ -377,7 +377,7 @@ class BuildGenerator(object):
         self.log = logging.getLogger()
 
         # Build and extract in directory for forked repositories in case of commit from forked repository
-        if fork_url != f"{MediaSdkDirectories.get_repo_url_by_name(self.default_options['REPO_NAME'])}.git":
+        if repo_url != f"{MediaSdkDirectories.get_repo_url_by_name(self.default_options['REPO_NAME'])}.git":
             self.default_options["REPOS_DIR"] = self.default_options["REPOS_FORKED_DIR"]
 
     def generate_build_config(self):
@@ -453,8 +453,8 @@ class BuildGenerator(object):
         if repo_name in self.product_repos:
             self.product_repos[repo_name]['branch'] = branch
             self.product_repos[repo_name]['commit_id'] = commit_id
-            if self.fork_url:
-                self.product_repos[repo_name]['url'] = self.fork_url
+            if self.repo_url:
+                self.product_repos[repo_name]['url'] = self.repo_url
         else:
             raise WrongTriggeredRepo('%s repository is not defined in the product '
                                      'configuration PRODUCT_REPOS', repo_name)
@@ -728,7 +728,9 @@ def main():
                         help='''Changed repository information
 in format: <repo_name>:<branch>:<commit_id>
 (ex: MediaSDK:master:52199a19d7809a77e3a474b195592cc427226c61)''')
-    parser.add_argument('-f', "--fork-url", metavar="URL", help='Link to forked repository')
+    parser.add_argument('-f', "--repo-url", metavar="URL", help='''Link to the repository.
+In most cases used to specify link to the forked repositories.
+Use this argument if you want to specify repository which is not present in mediasdk_directories.''')
     parser.add_argument('-b', "--build-type", default='release',
                         choices=['release', 'debug'],
                         help='Type of build')
@@ -757,7 +759,7 @@ in format: <repo_name>:<branch>:<commit_id>
         args.build_event,
         commit_time,
         args.changed_repo,
-        args.fork_url
+        args.repo_url
     )
 
     # We must create BuildGenerator anyway.

--- a/common/mediasdk_directories.py
+++ b/common/mediasdk_directories.py
@@ -63,7 +63,7 @@ class MediaSdkDirectories(object):
         # linux_open_source
         'MediaSDK': 'https://github.com/Intel-Media-SDK/MediaSDK',
         # test_repositories
-        'flow_test': 'git@github.com:Intel-Media-SDK/flow_test.git',
+        'flow_test': 'https://github.com/Intel-Media-SDK/flow_test',
     }
 
     @classmethod


### PR DESCRIPTION
This features is needed mainly for external contributors.  
  
- `--fork-url` starts in all cases (Pull Requests from forked and not forked repositories) (but it isn\`t mandatory by it\`s nature)
- Add new folder `repos_forked` which is cleaned before each extracting (to prevent conflicts because of same names of repositories)
- Decision about current type of repository (fork or official), from which we have to `pull` the changes, is on the side of `build_runner.py`