### PR TITLE
[CI build scripts] Running script with 'repo_states.json' file

### DIFF
--- a/build_scripts/build_runner.py
+++ b/build_scripts/build_runner.py
@@ -820,7 +820,7 @@ Use this argument if you want to specify repository which is not present in medi
             log.error('"--changed-repo" or "--repo-states" argument bust be added')
             exit(Error.CRITICAL.value)
         elif args.changed_repo and args.repo_states:
-            log.info('Priority for --changed-repo, not for --repo-states')
+            log.warning('The --repo-states argument is ignored because the --changed-repo is set')
 
         build_config.generate_build_config()
         build_config.run_stage(args.stage)

--- a/build_scripts/build_runner.py
+++ b/build_scripts/build_runner.py
@@ -375,6 +375,7 @@ class BuildGenerator(object):
         self.build_event = build_event
         self.commit_time = commit_time
         self.changed_repo = changed_repo
+        self.repo_states = None
         self.repo_url = repo_url
         self.build_state_file = root_dir / "build_state"
         self.default_options = {
@@ -397,9 +398,7 @@ class BuildGenerator(object):
         if changed_repo:
             if self.repo_url and self.repo_url != f"{MediaSdkDirectories.get_repo_url_by_name(changed_repo.split(':')[0])}.git":
                 self.default_options["REPOS_DIR"] = self.default_options["REPOS_FORKED_DIR"]
-
-        self.repo_states = None
-        if repo_states_file_path:
+        elif repo_states_file_path:
             repo_states_file = pathlib.Path(repo_states_file_path)
             if repo_states_file.exists():
                 with repo_states_file.open() as repo_states_json:

--- a/build_scripts/build_runner.py
+++ b/build_scripts/build_runner.py
@@ -474,10 +474,11 @@ class BuildGenerator(object):
         self.default_options['REPOS_DIR'].mkdir(parents=True, exist_ok=True)
         self.default_options['REPOS_FORKED_DIR'].mkdir(parents=True, exist_ok=True)
         self.default_options['PACK_DIR'].mkdir(parents=True, exist_ok=True)
+        triggered_repo = 'unknown'
 
         if self.changed_repo:
             repo_name, branch, commit_id = self.changed_repo.split(':')
-
+            triggered_repo = repo_name
             if repo_name in self.product_repos:
                 self.product_repos[repo_name]['branch'] = branch
                 self.product_repos[repo_name]['commit_id'] = commit_id
@@ -488,6 +489,8 @@ class BuildGenerator(object):
                                          'configuration PRODUCT_REPOS', repo_name)
         elif self.repo_states:
             for repo_name, values in self.repo_states.items():
+                if values['trigger']:
+                    triggered_repo = repo_name
                 self.product_repos[repo_name]['branch'] = values['branch']
                 self.product_repos[repo_name]['commit_id'] = values['commit_id']
                 self.product_repos[repo_name]['url'] = values['url']
@@ -496,9 +499,8 @@ class BuildGenerator(object):
 
         product_state.extract_all_repos()
 
-        if self.changed_repo:
-            product_state.save_repo_states(self.default_options["PACK_DIR"] / 'repo_states.json', trigger=repo_name)
-            shutil.copyfile(self.build_config_path, self.default_options["PACK_DIR"] / self.build_config_path.name)
+        product_state.save_repo_states(self.default_options["PACK_DIR"] / 'repo_states.json', trigger=triggered_repo)
+        shutil.copyfile(self.build_config_path, self.default_options["PACK_DIR"] / self.build_config_path.name)
 
         for action in self.actions[Stage.EXTRACT]:
             action.run()

--- a/build_scripts/build_runner.py
+++ b/build_scripts/build_runner.py
@@ -817,9 +817,6 @@ Use this argument if you want to specify repository which is not present in medi
         if not args.changed_repo and not args.sources:
             log.error('"--changed-repo" or "--sources" argument bust be added')
             exit(Error.CRITICAL.value)
-        elif not args.changed_repo and args.sources and args.stage in [Stage.COPY, Stage.PACK, Stage.INSTALL]:
-            log.error('Only "clean", "extract" and "build" stages available for running with "--sources" argument')
-            exit(Error.CRITICAL.value)
         elif args.changed_repo and args.sources:
             log.info('Priority for --changed-repo, not for --sources')
 

--- a/common/git_worker.py
+++ b/common/git_worker.py
@@ -144,9 +144,6 @@ class GitRepo(object):
             committed_date = self.repo.commit(self.commit_id).committed_date
             self.log.info("Committed date: %s", datetime.fromtimestamp(committed_date))
 
-        # if self.commit_id == 'HEAD' set SHA to variable self.commit_id
-        self.commit_id = str(self.repo.commit())
-
     @retry(stop=stop_after_attempt(5), wait=wait_exponential(multiplier=60))
     def clean(self):
         """

--- a/common/git_worker.py
+++ b/common/git_worker.py
@@ -253,10 +253,8 @@ class ProductState(object):
                 states[state.name] = {
                     'branch': state.branch,
                     'commit_id': state.commit_id,
-                    'url': state.url
+                    'url': state.url,
+                    'trigger': True if trigger == state.name else False
                 }
 
-                if trigger == state.name:
-                    states[state.name]['trigger'] = True
-
-            sources_state.write(json.dumps(states, indent=4))
+            sources_state.write(json.dumps(states, indent=4, sort_keys=True))


### PR DESCRIPTION
Build scripts can run with sources file.
In this case next arguments do not need to use:
--changed-repo,
--build-type,
--product-type,
--build-event,
--commit-time.

Also stages "install", "pack", "copy"
are not available with "--sources" argument

If --changed-repo and --sources are set, --sources will be ignored.

+ some updates in git_worker:
    improving sources.json file
    HEAD instead of SHA sum available in --changed-repo