### PR TITLE
[CI build scripts] clean.log disabling

### DIFF
--- a/build_scripts/build_runner.py
+++ b/build_scripts/build_runner.py
@@ -660,13 +660,13 @@ class BuildGenerator(object):
 
         self.default_options["LOGS_DIR"].mkdir(parents=True, exist_ok=True)
 
-        set_log_file(self.default_options["LOGS_DIR"] / (stage.value + '.log'))
         print('-' * 50)
 
         # CLEAN stage has it's own log strings inside.
-        # This stage remove all log files at first,
-        # and then writes results of it's own execution
+        # This stage remove all log files,
+        # but it does not create own log file
         if stage != Stage.CLEAN:
+            set_log_file(self.default_options["LOGS_DIR"] / (stage.value + '.log'))
             self.log.info("%sING", stage.name)
 
         if stage == Stage.CLEAN:


### PR DESCRIPTION
clean.log file does not create while cleaning
because it affects retrying of clean stage.

Clean logs writes only to default
file "_all.log" in build_scripts directory.