### PR TITLE
Add clang and dynamic creation in Builbot

### DIFF
--- a/bb/master/config.py
+++ b/bb/master/config.py
@@ -28,9 +28,6 @@ class Mode(Enum):
     PRODUCTION_MODE_PRIVATE = "production_mode_private"
     TEST_MODE = "test_mode"
 
-BUILD = "build"
-
-
 BUILDERS = {
     "build_master": {
         "name": "build-master-branch",
@@ -93,28 +90,30 @@ BUILDERS = {
     }
 }
 
+TESTERS = {
+    "test": {
+        "name": "test",
+        "product_type": "linux", # Product type of master (branch) build
+        "build_type": "release",
+    },
 
-TEST = {
-    "name": "test",
-    "product_type": "linux", # Product type of master (branch) build
-    "build_type": "release",
+    "test_api_latest": {
+        "name": "test-api-next",
+        "product_type": "api_latest", # Product type of master (branch) build
+        "build_type": "release",
+    }
 }
 
-TEST_API_LATEST = {
-    "name": "test-api-next",
-    "product_type": "api_latest", # Product type of master (branch) build
-    "build_type": "release",
-}
 
 WORKERS = {
-    BUILD: {
+    "build": {
         "b-1-10": {},
         "b-1-14": {}
     },
     "ubuntu": {
         "b-1-18": {}
     },
-    TEST["name"]: {
+    "test": {
         "t-1-17": {},
         "t-1-16": {}
     }
@@ -146,10 +145,10 @@ if CURRENT_MODE == Mode.PRODUCTION_MODE:
 
 elif CURRENT_MODE == Mode.PRODUCTION_MODE_PRIVATE:
     BUILDBOT_TITLE = "MediaSDK Private"
-    WORKERS = {BUILD: {"b-50-41": {},
-                       "b-50-61": {}},
-               BUILDERS["build_gcc_latest"]["name"]: {"b-999-999": {}},
-               TEST: {"t-999-999": {}}}
+    WORKERS = {"build": {"b-50-41": {},
+                         "b-50-61": {}},
+               "ubuntu": {"b-999-999": {}},
+               "test": {"t-999-999": {}}}
     GITHUB_OWNERS_REPO = msdk_secrets.EMBEDDED_REPO
     BUILDBOT_URL = msdk_secrets.BUILDBOT_URL
     MASTER_PRODUCT_TYPE = "embedded_private"

--- a/bb/master/config.py
+++ b/bb/master/config.py
@@ -30,34 +30,6 @@ class Mode(Enum):
 
 BUILD = "build"
 
-"""
-BUILD_MASTER = {
-    "name": "build-master-branch",
-    "product_conf_file": "conf_linux_public.py",
-    "product_type": "linux", # Product type of master (branch) build
-    "build_type": "release",
-    "api_latest": False,
-    "gcc_version": None
-}
-
-BUILD_NOT_MASTER = {
-    "name": "build",
-    "product_conf_file": "conf_linux_public.py",
-    "product_type": "linux", # Product type of master (branch) build
-    "build_type": "release",
-    "api_latest": False,
-    "gcc_version": None
-}
-
-BUILD_API_LATEST = {
-    "name": "build-api-next",
-    "product_conf_file": "conf_linux_public.py",
-    "product_type": "api_latest", # Product type of master (branch) build
-    "build_type": "release",
-    "api_latest": True,
-    "gcc_version": None
-}
-"""
 
 BUILDERS = {
     "build_master": {
@@ -66,6 +38,7 @@ BUILDERS = {
         "product_type": "linux", # Product type of master (branch) build
         "build_type": "release",
         "api_latest": False,
+        "compiler": None,
         "compiler_version": None,
         "branch": "master"
     },
@@ -76,6 +49,7 @@ BUILDERS = {
         "product_type": "linux", # Product type of master (branch) build
         "build_type": "release",
         "api_latest": False,
+        "compiler": None,
         "compiler_version": None,
         "branch": "(?!master)"
     },
@@ -86,6 +60,7 @@ BUILDERS = {
         "product_type": "api_latest", # Product type of master (branch) build
         "build_type": "release",
         "api_latest": True,
+        "compiler": None,
         "compiler_version": None,
         "branch": ".+?"
     },
@@ -96,6 +71,7 @@ BUILDERS = {
         "product_type": "linux_gcc_latest", # Product type of master (branch) build
         "build_type": "release",
         "api_latest": False,
+        "compiler": "gcc",
         "compiler_version": "8.1.0",
         "branch": ".+?"
     },
@@ -106,6 +82,7 @@ BUILDERS = {
         "product_type": "linux_clang_latest", # Product type of master (branch) build
         "build_type": "release",
         "api_latest": False,
+        "compiler": "clang",
         "compiler_version": "6.0",
         "branch": ".+?"
     }

--- a/bb/master/config.py
+++ b/bb/master/config.py
@@ -143,7 +143,7 @@ elif CURRENT_MODE == Mode.PRODUCTION_MODE_PRIVATE:
     BUILDBOT_TITLE = "MediaSDK Private"
     WORKERS = {BUILD: {"b-50-41": {},
                        "b-50-61": {}},
-               BUILD_GCC_LATEST["name"]: {"b-999-999": {}},
+               BUILDERS["build_gcc_latest"]["name"]: {"b-999-999": {}},
                TEST: {"t-999-999": {}}}
     GITHUB_OWNERS_REPO = msdk_secrets.EMBEDDED_REPO
     BUILDBOT_URL = msdk_secrets.BUILDBOT_URL

--- a/bb/master/config.py
+++ b/bb/master/config.py
@@ -28,94 +28,107 @@ class Mode(Enum):
     PRODUCTION_MODE_PRIVATE = "production_mode_private"
     TEST_MODE = "test_mode"
 
-TEST = "test" #TODO: tmp to determine workers
-
+"""
+Specification of BUILDERS:
+"name"              - name of build in Buildbot UI
+"product_conf_file" - product_config which should be used
+"product_type"      - Product type (all available types can be found in `build_runner.py`)
+"build_type"        - type of build (for example: "release")
+"api_latest"        - use api_latest? (True/False
+"compiler"          - compiler which should be used (env and product_config schould support this key)
+"compiler_version"  - version of compiler
+"branch"            - on this branch the build will be activated (supports Python re)
+"worker"            - worker(s) which should be used from `WORKERS`
+"""
 BUILDERS = {
     "build_master": {
         "name": "build-master-branch",
         "product_conf_file": "conf_linux_public.py",
-        "product_type": "linux", # Product type of master (branch) build
+        "product_type": "linux",
         "build_type": "release",
         "api_latest": False,
         "compiler": None,
         "compiler_version": None,
         "branch": "master",
-        "worker": "build" #TODO: change
+        "worker": "centos"
     },
 
     "build_not_master": {
         "name": "build",
         "product_conf_file": "conf_linux_public.py",
-        "product_type": "linux", # Product type of master (branch) build
+        "product_type": "linux",
         "build_type": "release",
         "api_latest": False,
         "compiler": None,
         "compiler_version": None,
         "branch": "(?!master)",
-        "worker": "build" #TODO: change
+        "worker": "centos"
     },
 
     "build_api_latest": {
         "name": "build-api-next",
         "product_conf_file": "conf_linux_public.py",
-        "product_type": "api_latest", # Product type of master (branch) build
+        "product_type": "api_latest",
         "build_type": "release",
         "api_latest": True,
         "compiler": None,
         "compiler_version": None,
         "branch": ".+?",
-        "worker": "build" #TODO: change
+        "worker": "centos"
     },
 
     "build_gcc_latest": {
         "name": "build-gcc-8.1.0",
         "product_conf_file": "conf_linux_public.py",
-        "product_type": "linux_gcc_latest", # Product type of master (branch) build
+        "product_type": "linux_gcc_latest",
         "build_type": "release",
         "api_latest": False,
         "compiler": "gcc",
         "compiler_version": "8.1.0",
         "branch": ".+?",
-        "worker": "ubuntu" #TODO: change
+        "worker": "ubuntu"
     },
 
     "build_clang_latest": {
         "name": "build-clang-6.0",
         "product_conf_file": "conf_linux_public.py",
-        "product_type": "linux_clang_latest", # Product type of master (branch) build
+        "product_type": "linux_clang_latest",
         "build_type": "release",
         "api_latest": False,
         "compiler": "clang",
         "compiler_version": "6.0",
         "branch": ".+?",
-        "worker": "ubuntu" #TODO: change
+        "worker": "ubuntu"
     }
 }
 
 TESTERS = {
     "test": {
         "name": "test",
-        "product_type": "linux", # Product type of master (branch) build
+        "product_type": "linux",
         "build_type": "release",
+        "worker": "centos_test"
     },
 
     "test_api_latest": {
         "name": "test-api-next",
-        "product_type": "api_latest", # Product type of master (branch) build
+        "product_type": "api_latest",
         "build_type": "release",
+        "worker": "centos_test"
     }
 }
 
 
 WORKERS = {
-    "build": {
+    "centos": {
         "b-1-10": {},
         "b-1-14": {}
     },
     "ubuntu": {
-        "b-1-18": {}
+        "b-1-18": {},
+        "b-1-18aux": {}
     },
-    TEST: {
+    "centos_test": {
         "t-1-17": {},
         "t-1-16": {}
     }
@@ -150,7 +163,7 @@ elif CURRENT_MODE == Mode.PRODUCTION_MODE_PRIVATE:
     WORKERS = {"build": {"b-50-41": {},
                          "b-50-61": {}},
                "ubuntu": {"b-999-999": {}},
-               TEST: {"t-999-999": {}}}
+               "centos_test": {"t-999-999": {}}}
     GITHUB_OWNERS_REPO = msdk_secrets.EMBEDDED_REPO
     BUILDBOT_URL = msdk_secrets.BUILDBOT_URL
     MASTER_PRODUCT_TYPE = "embedded_private"

--- a/bb/master/config.py
+++ b/bb/master/config.py
@@ -30,6 +30,7 @@ class Mode(Enum):
 
 BUILD = "build"
 
+"""
 BUILD_MASTER = {
     "name": "build-master-branch",
     "product_conf_file": "conf_linux_public.py",
@@ -56,14 +57,58 @@ BUILD_API_LATEST = {
     "api_latest": True,
     "gcc_version": None
 }
+"""
 
-BUILD_GCC_LATEST = {
-    "name": "build-gcc-8.1.0",
-    "product_conf_file": "conf_linux_public.py",
-    "product_type": "linux_gcc_latest", # Product type of master (branch) build
-    "build_type": "release",
-    "api_latest": False,
-    "gcc_version": "8.1.0"
+BUILDERS = {
+    "build_master": {
+        "name": "build-master-branch",
+        "product_conf_file": "conf_linux_public.py",
+        "product_type": "linux", # Product type of master (branch) build
+        "build_type": "release",
+        "api_latest": False,
+        "compiler_version": None,
+        "branch": "master"
+    },
+
+    "build_not_master": {
+        "name": "build",
+        "product_conf_file": "conf_linux_public.py",
+        "product_type": "linux", # Product type of master (branch) build
+        "build_type": "release",
+        "api_latest": False,
+        "compiler_version": None,
+        "branch": "(?!master)"
+    },
+
+    "build_api_latest": {
+        "name": "build-api-next",
+        "product_conf_file": "conf_linux_public.py",
+        "product_type": "api_latest", # Product type of master (branch) build
+        "build_type": "release",
+        "api_latest": True,
+        "compiler_version": None,
+        "branch": ".+?"
+    },
+
+    "build_gcc_latest": {
+        "name": "build-gcc-8.1.0",
+        "product_conf_file": "conf_linux_public.py",
+        "product_type": "linux_gcc_latest", # Product type of master (branch) build
+        "build_type": "release",
+        "api_latest": False,
+        "compiler_version": "8.1.0",
+        "branch": ".+?"
+    },
+
+    "build_clang_latest": {
+        "name": "build-clang-6.0",
+        "product_conf_file": "conf_linux_public.py",
+        "product_type": "linux_clang_latest", # Product type of master (branch) build
+        "build_type": "release",
+        "api_latest": False,
+        "compiler_version": "6.0",
+        "branch": ".+?"
+    }
 }
 
 
@@ -84,7 +129,7 @@ WORKERS = {
         "b-1-10": {},
         "b-1-14": {}
     },
-    BUILD_GCC_LATEST["name"]: {
+    BUILDERS["build_gcc_latest"]["name"]: {
         "b-1-18": {}
     },
     TEST["name"]: {

--- a/bb/master/config.py
+++ b/bb/master/config.py
@@ -28,6 +28,8 @@ class Mode(Enum):
     PRODUCTION_MODE_PRIVATE = "production_mode_private"
     TEST_MODE = "test_mode"
 
+TEST = "test" #TODO: tmp to determine workers
+
 BUILDERS = {
     "build_master": {
         "name": "build-master-branch",
@@ -113,7 +115,7 @@ WORKERS = {
     "ubuntu": {
         "b-1-18": {}
     },
-    "test": {
+    TEST: {
         "t-1-17": {},
         "t-1-16": {}
     }
@@ -148,7 +150,7 @@ elif CURRENT_MODE == Mode.PRODUCTION_MODE_PRIVATE:
     WORKERS = {"build": {"b-50-41": {},
                          "b-50-61": {}},
                "ubuntu": {"b-999-999": {}},
-               "test": {"t-999-999": {}}}
+               TEST: {"t-999-999": {}}}
     GITHUB_OWNERS_REPO = msdk_secrets.EMBEDDED_REPO
     BUILDBOT_URL = msdk_secrets.BUILDBOT_URL
     MASTER_PRODUCT_TYPE = "embedded_private"

--- a/bb/master/config.py
+++ b/bb/master/config.py
@@ -37,8 +37,13 @@ Specification of BUILDERS:
 "api_latest"        - if `True` it will enable product`s `api_latest` feature
 "compiler"          - compiler which should be used (env and product_config schould support this key)
 "compiler_version"  - version of compiler
-"branch"            - on this branch the build will be activated (supports Python re)
+"branch"            - on this branch pattern(!) the build will be activated (use Python re)
 "worker"            - worker(s) which should be used from `WORKERS`
+
+Python re examples:
+^master$ - build only master branch
+(?!master) - build everything except branch master
+.+? - build everything
 """
 BUILDERS = [
     {
@@ -49,7 +54,7 @@ BUILDERS = [
         "api_latest": False,
         "compiler": None,
         "compiler_version": None,
-        "branch": "master",
+        "branch": "^master$",
         "worker": "centos"
     },
 

--- a/bb/master/config.py
+++ b/bb/master/config.py
@@ -34,14 +34,14 @@ Specification of BUILDERS:
 "product_conf_file" - product_config which should be used
 "product_type"      - Product type (all available types can be found in `build_runner.py`)
 "build_type"        - type of build (for example: "release")
-"api_latest"        - use api_latest? (True/False
+"api_latest"        - if `True` it will enable product`s `api_latest` feature
 "compiler"          - compiler which should be used (env and product_config schould support this key)
 "compiler_version"  - version of compiler
 "branch"            - on this branch the build will be activated (supports Python re)
 "worker"            - worker(s) which should be used from `WORKERS`
 """
-BUILDERS = {
-    "build_master": {
+BUILDERS = [
+    {
         "name": "build-master-branch",
         "product_conf_file": "conf_linux_public.py",
         "product_type": "linux",
@@ -53,8 +53,8 @@ BUILDERS = {
         "worker": "centos"
     },
 
-    "build_not_master": {
-        "name": "build",
+    {
+        "name": "build", #build all except master branch
         "product_conf_file": "conf_linux_public.py",
         "product_type": "linux",
         "build_type": "release",
@@ -65,7 +65,7 @@ BUILDERS = {
         "worker": "centos"
     },
 
-    "build_api_latest": {
+    {
         "name": "build-api-next",
         "product_conf_file": "conf_linux_public.py",
         "product_type": "api_latest",
@@ -77,7 +77,7 @@ BUILDERS = {
         "worker": "centos"
     },
 
-    "build_gcc_latest": {
+    {
         "name": "build-gcc-8.1.0",
         "product_conf_file": "conf_linux_public.py",
         "product_type": "linux_gcc_latest",
@@ -89,7 +89,7 @@ BUILDERS = {
         "worker": "ubuntu"
     },
 
-    "build_clang_latest": {
+    {
         "name": "build-clang-6.0",
         "product_conf_file": "conf_linux_public.py",
         "product_type": "linux_clang_latest",
@@ -100,23 +100,23 @@ BUILDERS = {
         "branch": ".+?",
         "worker": "ubuntu"
     }
-}
+]
 
-TESTERS = {
-    "test": {
+TESTERS = [
+    {
         "name": "test",
         "product_type": "linux",
         "build_type": "release",
         "worker": "centos_test"
     },
 
-    "test_api_latest": {
+    {
         "name": "test-api-next",
         "product_type": "api_latest",
         "build_type": "release",
         "worker": "centos_test"
     }
-}
+]
 
 
 WORKERS = {

--- a/bb/master/config.py
+++ b/bb/master/config.py
@@ -40,7 +40,8 @@ BUILDERS = {
         "api_latest": False,
         "compiler": None,
         "compiler_version": None,
-        "branch": "master"
+        "branch": "master",
+        "worker": "build" #TODO: change
     },
 
     "build_not_master": {
@@ -51,7 +52,8 @@ BUILDERS = {
         "api_latest": False,
         "compiler": None,
         "compiler_version": None,
-        "branch": "(?!master)"
+        "branch": "(?!master)",
+        "worker": "build" #TODO: change
     },
 
     "build_api_latest": {
@@ -62,7 +64,8 @@ BUILDERS = {
         "api_latest": True,
         "compiler": None,
         "compiler_version": None,
-        "branch": ".+?"
+        "branch": ".+?",
+        "worker": "build" #TODO: change
     },
 
     "build_gcc_latest": {
@@ -73,7 +76,8 @@ BUILDERS = {
         "api_latest": False,
         "compiler": "gcc",
         "compiler_version": "8.1.0",
-        "branch": ".+?"
+        "branch": ".+?",
+        "worker": "ubuntu" #TODO: change
     },
 
     "build_clang_latest": {
@@ -84,7 +88,8 @@ BUILDERS = {
         "api_latest": False,
         "compiler": "clang",
         "compiler_version": "6.0",
-        "branch": ".+?"
+        "branch": ".+?",
+        "worker": "ubuntu" #TODO: change
     }
 }
 
@@ -106,7 +111,7 @@ WORKERS = {
         "b-1-10": {},
         "b-1-14": {}
     },
-    BUILDERS["build_gcc_latest"]["name"]: {
+    "ubuntu": {
         "b-1-18": {}
     },
     TEST["name"]: {

--- a/bb/master/master.cfg
+++ b/bb/master/master.cfg
@@ -134,7 +134,7 @@ for test in config.TESTERS.values():
     c["schedulers"].append(schedulers.Triggerable(name=test["name"],
                                                   builderNames=[test["name"]]))
     c["builders"].append(util.BuilderConfig(name=test["name"],
-                                            workernames=list(config.WORKERS[test["name"]].keys()),
+                                            workernames=list(config.WORKERS[config.TEST].keys()),
                                             factory=init_test_factory(test)))
 
 

--- a/bb/master/master.cfg
+++ b/bb/master/master.cfg
@@ -116,7 +116,25 @@ c["titleURL"] = config.REPO_URL
 c["buildbotURL"] = config.BUILDBOT_URL
 
 
+def create_schedulers(builders):
+    schedulers_list = []
+    for build in builders:
+        schedulers_list.append(schedulers.SingleBranchScheduler(name=build["name"],
+                                                                change_filter=util.ChangeFilter(category="mediasdk",
+                                                                                                branch=build["branch"]),
+                                                                treeStableTimer=config.BUILDBOT_TREE_STABLE_TIMER,
+                                                                builderNames=[build["name"]]))
+    return schedulers_list
+
+c["schedulers"] = create_schedulers(config.BUILDERS)
+
+c["schedulers"].append(schedulers.Triggerable(name=config.TEST["name"],
+                                              builderNames=[config.TEST["name"]]))
+c["schedulers"].append(schedulers.Triggerable(name=config.TEST_API_LATEST["name"],
+                                              builderNames=[config.TEST_API_LATEST["name"]]))
+
 # Schedulers
+"""
 c["schedulers"] = [
     schedulers.SingleBranchScheduler(name=config.BUILDERS["build_master"]["name"],
                                      change_filter=util.ChangeFilter(category="mediasdk",
@@ -153,35 +171,36 @@ c["schedulers"] = [
 
     schedulers.Triggerable(name=config.TEST_API_LATEST["name"],
                            builderNames=[config.TEST_API_LATEST["name"]])]
+"""
 
 # Builders
 c["builders"] = [
     util.BuilderConfig(name=config.BUILDERS["build_master"]["name"],
-                       workernames=[config.WORKERS[config.BUILD].keys()],
+                       workernames=list(config.WORKERS[config.BUILD].keys()),
                        factory=init_build_factory(config.BUILDERS["build_master"])),
 
     util.BuilderConfig(name=config.BUILDERS["build_not_master"]["name"],
-                       workernames=[config.WORKERS[config.BUILD].keys()],
+                       workernames=list(config.WORKERS[config.BUILD].keys()),
                        factory=init_build_factory(config.BUILDERS["build_not_master"])),
 
     util.BuilderConfig(name=config.BUILDERS["build_api_latest"]["name"],
-                       workernames=[config.WORKERS[config.BUILD].keys()],
+                       workernames=list(config.WORKERS[config.BUILD].keys()),
                        factory=init_build_factory(config.BUILDERS["build_api_latest"])),
 
     util.BuilderConfig(name=config.BUILDERS["build_gcc_latest"]["name"],
-                       workernames=[config.WORKERS[config.BUILDERS["build_gcc_latest"]["name"]].keys()],
+                       workernames=list(config.WORKERS[config.BUILDERS["build_gcc_latest"]["name"]].keys()),
                        factory=init_build_factory(config.BUILDERS["build_gcc_latest"])),
 
     util.BuilderConfig(name=config.BUILDERS["build_clang_latest"]["name"],
-                       workernames=[config.WORKERS[config.BUILDERS["build_gcc_latest"]["name"]].keys()],
+                       workernames=list(config.WORKERS[config.BUILDERS["build_gcc_latest"]["name"]].keys()),
                        factory=init_build_factory(config.BUILDERS["build_clang_latest"])),
 
     util.BuilderConfig(name=config.TEST["name"],
-                       workernames=[config.WORKERS[config.TEST["name"]].keys()],
+                       workernames=list(config.WORKERS[config.TEST["name"]].keys()),
                        factory=init_test_factory(config.TEST)),
 
     util.BuilderConfig(name=config.TEST_API_LATEST["name"],
-                       workernames=[config.WORKERS[config.TEST["name"]].keys()],
+                       workernames=list(config.WORKERS[config.TEST["name"]].keys()),
                        factory=init_test_factory(config.TEST_API_LATEST))]
 
 

--- a/bb/master/master.cfg
+++ b/bb/master/master.cfg
@@ -56,12 +56,11 @@ def init_build_factory(build_specification):
                           "--product-type", product_type,
                           "--repo-url", util.Interpolate(r"%(prop:repository)s"),
                           "--stage", stage.value,
+                          f"compiler={compiler}",
+                          f"compiler_version={compiler_version}",
                          ]
         if api_latest:
             shell_commands.append("api_latest=True")
-
-        shell_commands.append(f"compiler={compiler}")
-        shell_commands.append(f"compiler_version={compiler_version}")
 
         build_factory.addStep(
             steps.ShellCommand(command=shell_commands,
@@ -69,14 +68,13 @@ def init_build_factory(build_specification):
                                name=stage.value))
 
     #Trigger tests
-    if product_type == "linux":
-        build_factory.addStep(steps.Trigger(schedulerNames=[config.TESTERS["test"]["name"]],
-                                            waitForFinish=False,
-                                            updateSourceStamp=True))
-    elif product_type == "api_latest":
-        build_factory.addStep(steps.Trigger(schedulerNames=[config.TESTERS["test_api_latest"]["name"]],
-                                            waitForFinish=False,
-                                            updateSourceStamp=True))
+    #Tests will be triggered only if product types are similar
+    #Currently they will be triggered only for `build-master-branch`, `build`, `build-api-next`
+    for test_specification in config.TESTERS:
+        if product_type == test_specification["product_type"]:
+            build_factory.addStep(steps.Trigger(schedulerNames=[test_specification["name"]],
+                                                waitForFinish=False,
+                                                updateSourceStamp=True))
     return build_factory
 
 def init_test_factory(test_specification):
@@ -114,26 +112,29 @@ c["titleURL"] = config.REPO_URL
 c["buildbotURL"] = config.BUILDBOT_URL
 
 
+def get_workers(worker_pool):
+    return list(config.WORKERS[worker_pool].keys())
+
 # Create schedulers and builders for builds
 c["schedulers"] = []
 c["builders"] = []
-for build in config.BUILDERS.values():
-    c["schedulers"].append(schedulers.SingleBranchScheduler(name=build["name"],
+for build_specification in config.BUILDERS:
+    c["schedulers"].append(schedulers.SingleBranchScheduler(name=build_specification["name"],
                                                             change_filter=util.ChangeFilter(category="mediasdk",
-                                                                                            branch=build["branch"]),
+                                                                                            branch=build_specification["branch"]),
                                                             treeStableTimer=config.BUILDBOT_TREE_STABLE_TIMER,
-                                                            builderNames=[build["name"]]))
-    c["builders"].append(util.BuilderConfig(name=build["name"],
-                                            workernames=list(config.WORKERS[build["worker"]].keys()),
-                                            factory=init_build_factory(build)))
+                                                            builderNames=[build_specification["name"]]))
+    c["builders"].append(util.BuilderConfig(name=build_specification["name"],
+                                            workernames=get_workers(build_specification["worker"]),
+                                            factory=init_build_factory(build_specification)))
 
 # Create schedulers and builders for tests
-for test in config.TESTERS.values():
-    c["schedulers"].append(schedulers.Triggerable(name=test["name"],
-                                                  builderNames=[test["name"]]))
-    c["builders"].append(util.BuilderConfig(name=test["name"],
-                                            workernames=list(config.WORKERS[test["worker"]].keys()),
-                                            factory=init_test_factory(test)))
+for test_specification in config.TESTERS:
+    c["schedulers"].append(schedulers.Triggerable(name=test_specification["name"],
+                                                  builderNames=[test_specification["name"]]))
+    c["builders"].append(util.BuilderConfig(name=test_specification["name"],
+                                            workernames=get_workers(test_specification["worker"]),
+                                            factory=init_test_factory(test_specification)))
 
 
 # Push status of build to the Github

--- a/bb/master/master.cfg
+++ b/bb/master/master.cfg
@@ -121,7 +121,7 @@ c["builders"] = []
 for build_specification in config.BUILDERS:
     c["schedulers"].append(schedulers.SingleBranchScheduler(name=build_specification["name"],
                                                             change_filter=util.ChangeFilter(category="mediasdk",
-                                                                                            branch=build_specification["branch"]),
+                                                                                            branch_re=build_specification["branch"]),
                                                             treeStableTimer=config.BUILDBOT_TREE_STABLE_TIMER,
                                                             builderNames=[build_specification["name"]]))
     c["builders"].append(util.BuilderConfig(name=build_specification["name"],

--- a/bb/master/master.cfg
+++ b/bb/master/master.cfg
@@ -98,18 +98,16 @@ def init_test_factory(test_specification):
 
 c = BuildmasterConfig = {}
 
-c["workers"] = []
-
 # Add workers
+c["workers"] = []
 for worker_ in config.WORKERS.values():
     for w_name, prop in worker_.items():
         c["workers"].append(worker.Worker(w_name, config.WORKER_PASS,
                                           properties=prop,
                                           max_builds=1)) # To disable parallel builds on one worker
 
-c["protocols"] = {"pb": {"port": config.WORKER_PORT}}
-
 # Basic config
+c["protocols"] = {"pb": {"port": config.WORKER_PORT}}
 c["buildbotNetUsageData"] = config.BUILDBOT_NET_USAGE_DATA
 c["title"] = config.BUILDBOT_TITLE
 c["titleURL"] = config.REPO_URL
@@ -134,7 +132,7 @@ for test in config.TESTERS.values():
     c["schedulers"].append(schedulers.Triggerable(name=test["name"],
                                                   builderNames=[test["name"]]))
     c["builders"].append(util.BuilderConfig(name=test["name"],
-                                            workernames=list(config.WORKERS[config.TEST].keys()),
+                                            workernames=list(config.WORKERS[test["worker"]].keys()),
                                             factory=init_test_factory(test)))
 
 
@@ -152,6 +150,7 @@ c["services"] = [
 #                                 verbose=True,
 #                                 debug=True)]
 
+# Get changes
 c["change_source"] = []
 
 def pull_request_filter(pull_request_message):

--- a/bb/master/master.cfg
+++ b/bb/master/master.cfg
@@ -38,7 +38,7 @@ def init_build_factory(build_specification):
     product_type=build_specification["product_type"]
     build_type=build_specification["build_type"]
     api_latest=build_specification["api_latest"]
-    gcc_version=build_specification["gcc_version"] #TODO: rename it
+    gcc_version=build_specification["compiler_version"] #TODO: rename it
     #compiler
     #compiler_version
     build_factory = util.BuildFactory()

--- a/bb/master/master.cfg
+++ b/bb/master/master.cfg
@@ -34,13 +34,12 @@ class Stage(Enum):
     COPY = "copy"
 
 def init_build_factory(build_specification):
-    conf_file=build_specification["product_conf_file"]
-    product_type=build_specification["product_type"]
-    build_type=build_specification["build_type"]
-    api_latest=build_specification["api_latest"]
-    gcc_version=build_specification["compiler_version"] #TODO: rename it
-    #compiler
-    #compiler_version
+    conf_file = build_specification["product_conf_file"]
+    product_type = build_specification["product_type"]
+    build_type = build_specification["build_type"]
+    api_latest = build_specification["api_latest"]
+    compiler = build_specification["compiler"]
+    compiler_version = build_specification["compiler_version"]
     build_factory = util.BuildFactory()
 
     #Build by stages: clean, extract, build, install, pack, copy
@@ -61,7 +60,8 @@ def init_build_factory(build_specification):
         if api_latest:
             shell_commands.append("api_latest=True")
 
-        shell_commands.append(f"gcc_version={gcc_version}")
+        shell_commands.append(f"compiler={compiler}")
+        shell_commands.append(f"compiler_version={compiler_version}")
 
         build_factory.addStep(
             steps.ShellCommand(command=shell_commands,
@@ -79,8 +79,11 @@ def init_build_factory(build_specification):
                                             updateSourceStamp=True))
     return build_factory
 
-def init_test_factory(product_type, build_type):
+def init_test_factory(test_specification):
+    product_type = test_specification["product_type"]
+    build_type = test_specification["build_type"]
     test_factory = util.BuildFactory()
+
     test_factory.addStep(
         steps.ShellCommand(command=[config.RUN_COMMAND,
                                     "test_adapter.py",
@@ -144,73 +147,42 @@ c["schedulers"] = [
                                                                      branch_re=".+?"),
                                      treeStableTimer=config.BUILDBOT_TREE_STABLE_TIMER,
                                      builderNames=[config.BUILDERS["build_clang_latest"]["name"]]),
+
     schedulers.Triggerable(name=config.TEST["name"],
                            builderNames=[config.TEST["name"]]),
+
     schedulers.Triggerable(name=config.TEST_API_LATEST["name"],
                            builderNames=[config.TEST_API_LATEST["name"]])]
-
-
-#Init build factories
-"""
-build_factory = init_build_factory(conf_file=config.BUILD_MASTER["product_conf_file"],
-                                   product_type=config.BUILD_MASTER["product_type"],
-                                   build_type=config.BUILD_MASTER["build_type"],
-                                   api_latest=config.BUILD_MASTER["api_latest"],
-                                   gcc_version=config.BUILD_MASTER["gcc_version"])
-
-build_not_master_factory = init_build_factory(conf_file=config.BUILD_NOT_MASTER["product_conf_file"],
-                                              product_type=config.BUILD_NOT_MASTER["product_type"],
-                                              build_type=config.BUILD_NOT_MASTER["build_type"],
-                                              api_latest=config.BUILD_NOT_MASTER["api_latest"],
-                                              gcc_version=config.BUILD_NOT_MASTER["gcc_version"])
-
-build_api_latest_factory = init_build_factory(conf_file=config.BUILD_API_LATEST["product_conf_file"],
-                                              product_type=config.BUILD_API_LATEST["product_type"],
-                                              build_type=config.BUILD_API_LATEST["build_type"],
-                                              api_latest=config.BUILD_API_LATEST["api_latest"],
-                                              gcc_version=config.BUILD_API_LATEST["gcc_version"])
-
-build_gcc_latest_factory = init_build_factory(conf_file=config.BUILD_GCC_LATEST["product_conf_file"],
-                                              product_type=config.BUILD_GCC_LATEST["product_type"],
-                                              build_type=config.BUILD_GCC_LATEST["build_type"],
-                                              api_latest=config.BUILD_GCC_LATEST["api_latest"],
-                                              gcc_version=config.BUILD_GCC_LATEST["gcc_version"])
-"""
-#Init tests
-test_factory = init_test_factory(config.TEST["product_type"],
-                                 config.TEST["build_type"])
-test_api_factory = init_test_factory(config.TEST_API_LATEST["product_type"],
-                                     config.TEST_API_LATEST["build_type"])
-
 
 # Builders
 c["builders"] = [
     util.BuilderConfig(name=config.BUILDERS["build_master"]["name"],
-                       workernames=list(config.WORKERS[config.BUILD].keys()),
+                       workernames=[config.WORKERS[config.BUILD].keys()],
                        factory=init_build_factory(config.BUILDERS["build_master"])),
 
     util.BuilderConfig(name=config.BUILDERS["build_not_master"]["name"],
-                       workernames=list(config.WORKERS[config.BUILD].keys()),
+                       workernames=[config.WORKERS[config.BUILD].keys()],
                        factory=init_build_factory(config.BUILDERS["build_not_master"])),
 
     util.BuilderConfig(name=config.BUILDERS["build_api_latest"]["name"],
-                       workernames=list(config.WORKERS[config.BUILD].keys()),
+                       workernames=[config.WORKERS[config.BUILD].keys()],
                        factory=init_build_factory(config.BUILDERS["build_api_latest"])),
 
     util.BuilderConfig(name=config.BUILDERS["build_gcc_latest"]["name"],
-                       workernames=list(config.WORKERS[config.BUILDERS["build_gcc_latest"]["name"]].keys()),
+                       workernames=[config.WORKERS[config.BUILDERS["build_gcc_latest"]["name"]].keys()],
                        factory=init_build_factory(config.BUILDERS["build_gcc_latest"])),
 
     util.BuilderConfig(name=config.BUILDERS["build_clang_latest"]["name"],
-                       workernames=list(config.WORKERS[config.BUILDERS["build_gcc_latest"]["name"]].keys()), #TODO: rewrite
+                       workernames=[config.WORKERS[config.BUILDERS["build_gcc_latest"]["name"]].keys()],
                        factory=init_build_factory(config.BUILDERS["build_clang_latest"])),
 
     util.BuilderConfig(name=config.TEST["name"],
-                       workernames=list(config.WORKERS[config.TEST["name"]].keys()),
-                       factory=test_factory),
+                       workernames=[config.WORKERS[config.TEST["name"]].keys()],
+                       factory=init_test_factory(config.TEST)),
+
     util.BuilderConfig(name=config.TEST_API_LATEST["name"],
-                       workernames=list(config.WORKERS[config.TEST["name"]].keys()),
-                       factory=test_api_factory)]
+                       workernames=[config.WORKERS[config.TEST["name"]].keys()],
+                       factory=init_test_factory(config.TEST_API_LATEST))]
 
 
 # Push status of build to the Github

--- a/bb/master/master.cfg
+++ b/bb/master/master.cfg
@@ -33,7 +33,14 @@ class Stage(Enum):
     PACK = "pack"
     COPY = "copy"
 
-def init_build_factory(conf_file, product_type, build_type, api_latest, gcc_version):
+def init_build_factory(build_specification):
+    conf_file=build_specification["product_conf_file"]
+    product_type=build_specification["product_type"]
+    build_type=build_specification["build_type"]
+    api_latest=build_specification["api_latest"]
+    gcc_version=build_specification["gcc_version"] #TODO: rename it
+    #compiler
+    #compiler_version
     build_factory = util.BuildFactory()
 
     #Build by stages: clean, extract, build, install, pack, copy
@@ -108,26 +115,35 @@ c["buildbotURL"] = config.BUILDBOT_URL
 
 # Schedulers
 c["schedulers"] = [
-    schedulers.SingleBranchScheduler(name=config.BUILD_MASTER["name"],
+    schedulers.SingleBranchScheduler(name=config.BUILDERS["build_master"]["name"],
                                      change_filter=util.ChangeFilter(category="mediasdk",
                                                                      branch="master"),
                                      treeStableTimer=config.BUILDBOT_TREE_STABLE_TIMER,
-                                     builderNames=[config.BUILD_MASTER["name"]]),
-    schedulers.SingleBranchScheduler(name=config.BUILD_NOT_MASTER["name"],
+                                     builderNames=[config.BUILDERS["build_master"]["name"]]),
+
+    schedulers.SingleBranchScheduler(name=config.BUILDERS["build_not_master"]["name"],
                                      change_filter=util.ChangeFilter(category="mediasdk",
                                                                      branch_re="(?!master)"),
                                      treeStableTimer=config.BUILDBOT_TREE_STABLE_TIMER,
-                                     builderNames=[config.BUILD_NOT_MASTER["name"]]),
-    schedulers.SingleBranchScheduler(name=config.BUILD_API_LATEST["name"],
+                                     builderNames=[config.BUILDERS["build_not_master"]["name"]]),
+
+    schedulers.SingleBranchScheduler(name=config.BUILDERS["build_api_latest"]["name"],
                                      change_filter=util.ChangeFilter(category="mediasdk",
                                                                      branch_re=".+?"),
                                      treeStableTimer=config.BUILDBOT_TREE_STABLE_TIMER,
-                                     builderNames=[config.BUILD_API_LATEST["name"]]),
-    schedulers.SingleBranchScheduler(name=config.BUILD_GCC_LATEST["name"],
+                                     builderNames=[config.BUILDERS["build_api_latest"]["name"]]),
+
+    schedulers.SingleBranchScheduler(name=config.BUILDERS["build_gcc_latest"]["name"],
                                      change_filter=util.ChangeFilter(category="mediasdk",
                                                                      branch_re=".+?"),
                                      treeStableTimer=config.BUILDBOT_TREE_STABLE_TIMER,
-                                     builderNames=[config.BUILD_GCC_LATEST["name"]]),
+                                     builderNames=[config.BUILDERS["build_gcc_latest"]["name"]]),
+
+    schedulers.SingleBranchScheduler(name=config.BUILDERS["build_clang_latest"]["name"],
+                                     change_filter=util.ChangeFilter(category="mediasdk",
+                                                                     branch_re=".+?"),
+                                     treeStableTimer=config.BUILDBOT_TREE_STABLE_TIMER,
+                                     builderNames=[config.BUILDERS["build_clang_latest"]["name"]]),
     schedulers.Triggerable(name=config.TEST["name"],
                            builderNames=[config.TEST["name"]]),
     schedulers.Triggerable(name=config.TEST_API_LATEST["name"],
@@ -135,6 +151,7 @@ c["schedulers"] = [
 
 
 #Init build factories
+"""
 build_factory = init_build_factory(conf_file=config.BUILD_MASTER["product_conf_file"],
                                    product_type=config.BUILD_MASTER["product_type"],
                                    build_type=config.BUILD_MASTER["build_type"],
@@ -158,6 +175,7 @@ build_gcc_latest_factory = init_build_factory(conf_file=config.BUILD_GCC_LATEST[
                                               build_type=config.BUILD_GCC_LATEST["build_type"],
                                               api_latest=config.BUILD_GCC_LATEST["api_latest"],
                                               gcc_version=config.BUILD_GCC_LATEST["gcc_version"])
+"""
 #Init tests
 test_factory = init_test_factory(config.TEST["product_type"],
                                  config.TEST["build_type"])
@@ -167,18 +185,26 @@ test_api_factory = init_test_factory(config.TEST_API_LATEST["product_type"],
 
 # Builders
 c["builders"] = [
-    util.BuilderConfig(name=config.BUILD_MASTER["name"],
+    util.BuilderConfig(name=config.BUILDERS["build_master"]["name"],
                        workernames=list(config.WORKERS[config.BUILD].keys()),
-                       factory=build_factory),
-    util.BuilderConfig(name=config.BUILD_NOT_MASTER["name"],
+                       factory=init_build_factory(config.BUILDERS["build_master"])),
+
+    util.BuilderConfig(name=config.BUILDERS["build_not_master"]["name"],
                        workernames=list(config.WORKERS[config.BUILD].keys()),
-                       factory=build_not_master_factory),
-    util.BuilderConfig(name=config.BUILD_API_LATEST["name"],
+                       factory=init_build_factory(config.BUILDERS["build_not_master"])),
+
+    util.BuilderConfig(name=config.BUILDERS["build_api_latest"]["name"],
                        workernames=list(config.WORKERS[config.BUILD].keys()),
-                       factory=build_api_latest_factory),
-    util.BuilderConfig(name=config.BUILD_GCC_LATEST["name"],
-                       workernames=list(config.WORKERS[config.BUILD_GCC_LATEST["name"]].keys()),
-                       factory=build_gcc_latest_factory),
+                       factory=init_build_factory(config.BUILDERS["build_api_latest"])),
+
+    util.BuilderConfig(name=config.BUILDERS["build_gcc_latest"]["name"],
+                       workernames=list(config.WORKERS[config.BUILDERS["build_gcc_latest"]["name"]].keys()),
+                       factory=init_build_factory(config.BUILDERS["build_gcc_latest"])),
+
+    util.BuilderConfig(name=config.BUILDERS["build_clang_latest"]["name"],
+                       workernames=list(config.WORKERS[config.BUILDERS["build_gcc_latest"]["name"]].keys()), #TODO: rewrite
+                       factory=init_build_factory(config.BUILDERS["build_clang_latest"])),
+
     util.BuilderConfig(name=config.TEST["name"],
                        workernames=list(config.WORKERS[config.TEST["name"]].keys()),
                        factory=test_factory),

--- a/bb/master/master.cfg
+++ b/bb/master/master.cfg
@@ -116,17 +116,13 @@ c["titleURL"] = config.REPO_URL
 c["buildbotURL"] = config.BUILDBOT_URL
 
 
-def create_schedulers(builders):
-    schedulers_list = []
-    for build in builders:
-        schedulers_list.append(schedulers.SingleBranchScheduler(name=build["name"],
-                                                                change_filter=util.ChangeFilter(category="mediasdk",
-                                                                                                branch=build["branch"]),
-                                                                treeStableTimer=config.BUILDBOT_TREE_STABLE_TIMER,
-                                                                builderNames=[build["name"]]))
-    return schedulers_list
-
-c["schedulers"] = create_schedulers(config.BUILDERS)
+c["schedulers"] = []
+for build in config.BUILDERS.values():
+    c["schedulers"].append(schedulers.SingleBranchScheduler(name=build["name"],
+                                                            change_filter=util.ChangeFilter(category="mediasdk",
+                                                                                            branch=build["branch"]),
+                                                            treeStableTimer=config.BUILDBOT_TREE_STABLE_TIMER,
+                                                            builderNames=[build["name"]]))
 
 c["schedulers"].append(schedulers.Triggerable(name=config.TEST["name"],
                                               builderNames=[config.TEST["name"]]))

--- a/bb/master/master.cfg
+++ b/bb/master/master.cfg
@@ -116,6 +116,7 @@ c["titleURL"] = config.REPO_URL
 c["buildbotURL"] = config.BUILDBOT_URL
 
 
+# Create schedulers
 c["schedulers"] = []
 for build in config.BUILDERS.values():
     c["schedulers"].append(schedulers.SingleBranchScheduler(name=build["name"],
@@ -124,51 +125,27 @@ for build in config.BUILDERS.values():
                                                             treeStableTimer=config.BUILDBOT_TREE_STABLE_TIMER,
                                                             builderNames=[build["name"]]))
 
+#TODO: create in loop
 c["schedulers"].append(schedulers.Triggerable(name=config.TEST["name"],
                                               builderNames=[config.TEST["name"]]))
 c["schedulers"].append(schedulers.Triggerable(name=config.TEST_API_LATEST["name"],
                                               builderNames=[config.TEST_API_LATEST["name"]]))
 
-# Schedulers
+# Create builders
+c["builders"] = []
+for build in config.BUILDERS.values():
+    c["builders"].append(util.BuilderConfig(name=build["name"],
+                                            workernames=list(config.WORKERS[build["worker"]].keys()), #TODO: add types for workers!!!
+                                            factory=init_build_factory(build)))
+#TODO: create in loop
+c["builders"].append(util.BuilderConfig(name=config.TEST["name"],
+                                        workernames=list(config.WORKERS[config.TEST["name"]].keys()),
+                                        factory=init_test_factory(config.TEST)))
+c["builders"].append(util.BuilderConfig(name=config.TEST_API_LATEST["name"],
+                                        workernames=list(config.WORKERS[config.TEST["name"]].keys()),
+                                        factory=init_test_factory(config.TEST_API_LATEST)))
+
 """
-c["schedulers"] = [
-    schedulers.SingleBranchScheduler(name=config.BUILDERS["build_master"]["name"],
-                                     change_filter=util.ChangeFilter(category="mediasdk",
-                                                                     branch="master"),
-                                     treeStableTimer=config.BUILDBOT_TREE_STABLE_TIMER,
-                                     builderNames=[config.BUILDERS["build_master"]["name"]]),
-
-    schedulers.SingleBranchScheduler(name=config.BUILDERS["build_not_master"]["name"],
-                                     change_filter=util.ChangeFilter(category="mediasdk",
-                                                                     branch_re="(?!master)"),
-                                     treeStableTimer=config.BUILDBOT_TREE_STABLE_TIMER,
-                                     builderNames=[config.BUILDERS["build_not_master"]["name"]]),
-
-    schedulers.SingleBranchScheduler(name=config.BUILDERS["build_api_latest"]["name"],
-                                     change_filter=util.ChangeFilter(category="mediasdk",
-                                                                     branch_re=".+?"),
-                                     treeStableTimer=config.BUILDBOT_TREE_STABLE_TIMER,
-                                     builderNames=[config.BUILDERS["build_api_latest"]["name"]]),
-
-    schedulers.SingleBranchScheduler(name=config.BUILDERS["build_gcc_latest"]["name"],
-                                     change_filter=util.ChangeFilter(category="mediasdk",
-                                                                     branch_re=".+?"),
-                                     treeStableTimer=config.BUILDBOT_TREE_STABLE_TIMER,
-                                     builderNames=[config.BUILDERS["build_gcc_latest"]["name"]]),
-
-    schedulers.SingleBranchScheduler(name=config.BUILDERS["build_clang_latest"]["name"],
-                                     change_filter=util.ChangeFilter(category="mediasdk",
-                                                                     branch_re=".+?"),
-                                     treeStableTimer=config.BUILDBOT_TREE_STABLE_TIMER,
-                                     builderNames=[config.BUILDERS["build_clang_latest"]["name"]]),
-
-    schedulers.Triggerable(name=config.TEST["name"],
-                           builderNames=[config.TEST["name"]]),
-
-    schedulers.Triggerable(name=config.TEST_API_LATEST["name"],
-                           builderNames=[config.TEST_API_LATEST["name"]])]
-"""
-
 # Builders
 c["builders"] = [
     util.BuilderConfig(name=config.BUILDERS["build_master"]["name"],
@@ -198,7 +175,7 @@ c["builders"] = [
     util.BuilderConfig(name=config.TEST_API_LATEST["name"],
                        workernames=list(config.WORKERS[config.TEST["name"]].keys()),
                        factory=init_test_factory(config.TEST_API_LATEST))]
-
+"""
 
 # Push status of build to the Github
 c["services"] = [

--- a/bb/master/master.cfg
+++ b/bb/master/master.cfg
@@ -70,11 +70,11 @@ def init_build_factory(build_specification):
 
     #Trigger tests
     if product_type == "linux":
-        build_factory.addStep(steps.Trigger(schedulerNames=[config.TEST["name"]],
+        build_factory.addStep(steps.Trigger(schedulerNames=[config.TESTERS["test"]["name"]],
                                             waitForFinish=False,
                                             updateSourceStamp=True))
     elif product_type == "api_latest":
-        build_factory.addStep(steps.Trigger(schedulerNames=[config.TEST_API_LATEST["name"]],
+        build_factory.addStep(steps.Trigger(schedulerNames=[config.TESTERS["test_api_latest"]["name"]],
                                             waitForFinish=False,
                                             updateSourceStamp=True))
     return build_factory
@@ -116,66 +116,27 @@ c["titleURL"] = config.REPO_URL
 c["buildbotURL"] = config.BUILDBOT_URL
 
 
-# Create schedulers
+# Create schedulers and builders for builds
 c["schedulers"] = []
+c["builders"] = []
 for build in config.BUILDERS.values():
     c["schedulers"].append(schedulers.SingleBranchScheduler(name=build["name"],
                                                             change_filter=util.ChangeFilter(category="mediasdk",
                                                                                             branch=build["branch"]),
                                                             treeStableTimer=config.BUILDBOT_TREE_STABLE_TIMER,
                                                             builderNames=[build["name"]]))
-
-#TODO: create in loop
-c["schedulers"].append(schedulers.Triggerable(name=config.TEST["name"],
-                                              builderNames=[config.TEST["name"]]))
-c["schedulers"].append(schedulers.Triggerable(name=config.TEST_API_LATEST["name"],
-                                              builderNames=[config.TEST_API_LATEST["name"]]))
-
-# Create builders
-c["builders"] = []
-for build in config.BUILDERS.values():
     c["builders"].append(util.BuilderConfig(name=build["name"],
-                                            workernames=list(config.WORKERS[build["worker"]].keys()), #TODO: add types for workers!!!
+                                            workernames=list(config.WORKERS[build["worker"]].keys()),
                                             factory=init_build_factory(build)))
-#TODO: create in loop
-c["builders"].append(util.BuilderConfig(name=config.TEST["name"],
-                                        workernames=list(config.WORKERS[config.TEST["name"]].keys()),
-                                        factory=init_test_factory(config.TEST)))
-c["builders"].append(util.BuilderConfig(name=config.TEST_API_LATEST["name"],
-                                        workernames=list(config.WORKERS[config.TEST["name"]].keys()),
-                                        factory=init_test_factory(config.TEST_API_LATEST)))
 
-"""
-# Builders
-c["builders"] = [
-    util.BuilderConfig(name=config.BUILDERS["build_master"]["name"],
-                       workernames=list(config.WORKERS[config.BUILD].keys()),
-                       factory=init_build_factory(config.BUILDERS["build_master"])),
+# Create schedulers and builders for tests
+for test in config.TESTERS.values():
+    c["schedulers"].append(schedulers.Triggerable(name=test["name"],
+                                                  builderNames=[test["name"]]))
+    c["builders"].append(util.BuilderConfig(name=test["name"],
+                                            workernames=list(config.WORKERS[test["name"]].keys()),
+                                            factory=init_test_factory(test)))
 
-    util.BuilderConfig(name=config.BUILDERS["build_not_master"]["name"],
-                       workernames=list(config.WORKERS[config.BUILD].keys()),
-                       factory=init_build_factory(config.BUILDERS["build_not_master"])),
-
-    util.BuilderConfig(name=config.BUILDERS["build_api_latest"]["name"],
-                       workernames=list(config.WORKERS[config.BUILD].keys()),
-                       factory=init_build_factory(config.BUILDERS["build_api_latest"])),
-
-    util.BuilderConfig(name=config.BUILDERS["build_gcc_latest"]["name"],
-                       workernames=list(config.WORKERS[config.BUILDERS["build_gcc_latest"]["name"]].keys()),
-                       factory=init_build_factory(config.BUILDERS["build_gcc_latest"])),
-
-    util.BuilderConfig(name=config.BUILDERS["build_clang_latest"]["name"],
-                       workernames=list(config.WORKERS[config.BUILDERS["build_gcc_latest"]["name"]].keys()),
-                       factory=init_build_factory(config.BUILDERS["build_clang_latest"])),
-
-    util.BuilderConfig(name=config.TEST["name"],
-                       workernames=list(config.WORKERS[config.TEST["name"]].keys()),
-                       factory=init_test_factory(config.TEST)),
-
-    util.BuilderConfig(name=config.TEST_API_LATEST["name"],
-                       workernames=list(config.WORKERS[config.TEST["name"]].keys()),
-                       factory=init_test_factory(config.TEST_API_LATEST))]
-"""
 
 # Push status of build to the Github
 c["services"] = [

--- a/build_scripts/build_runner.py
+++ b/build_scripts/build_runner.py
@@ -886,7 +886,7 @@ which is not present in mediasdk_directories.''')
     parser.add_argument('-p', "--product-type", default='linux',
                         choices=['linux', 'embedded', 'open_source', 'windows',
                                  'windows_uwp', 'api_latest', 'embedded_private', 'android',
-                                 'linux_gcc_latest'],
+                                 'linux_gcc_latest', 'linux_clang_latest'],
                         help='Type of product')
     parser.add_argument('-e', "--build-event", default='commit',
                         choices=['pre_commit', 'commit', 'nightly', 'weekly'],


### PR DESCRIPTION
- Add clang CI
- Refactoring: add dynamic creation of schedulers, builders and factories
- More comments and explaining
- Improved `config.py` logic
- Add new aux worker "b-1-18aux"

As a result after the refactoring we can add new `BUILDERS` very easy.
Some basic logic:
- use of strict association of scheduler - builder
- new worker pool tagging (which can be discussed)

Needed change: https://github.com/Intel-Media-SDK/product-configs/pull/22