### PR TITLE
[Build scripts] To build HEAD revision

### DIFF
--- a/build_scripts/build_runner.py
+++ b/build_scripts/build_runner.py
@@ -413,6 +413,8 @@ class BuildGenerator(object):
                             break
             else:
                 raise Exception(f'{repo_states_file} does not exist')
+        else:
+            self.branch_name = 'master'
 
     def generate_build_config(self):
         """
@@ -769,6 +771,10 @@ class BuildGenerator(object):
                 if repo['trigger']:
                     branch = repo['branch']
                     commit_id = repo['commit_id']
+        else:
+            # "--changed-repo" or "--repo-states" arguments are not set, "HEAD" revision and "master" branch are used
+            branch = 'master'
+            commit_id = 'HEAD'
 
         build_dir = MediaSdkDirectories.get_build_dir(
             branch, self.build_event, commit_id,
@@ -997,8 +1003,8 @@ which is not present in mediasdk_directories.''')
     # and fails, class will not be created.
     try:
         if not parsed_args.changed_repo and not parsed_args.repo_states:
-            log.error('"--changed-repo" or "--repo-states" argument bust be added')
-            exit(ErrorCode.CRITICAL.value)
+            log.warning('"--changed-repo" or "--repo-states" arguments are not set, "HEAD" revision and '
+                        '"master" branch be used')
         elif parsed_args.changed_repo and parsed_args.repo_states:
             log.warning('The --repo-states argument is ignored because the --changed-repo is set')
 

--- a/common/git_worker.py
+++ b/common/git_worker.py
@@ -239,8 +239,11 @@ class ProductState(object):
         for repo in self.repo_states:
             if not repo.commit_id:
                 repo.prepare_repo()
-                repo.revert_commit_by_time(commit_timestamp)
-                repo.checkout()
+                # if parameters '--commit-time', '--changed-repo' and '--repo-states' didn't set
+                # then variable 'commit_timestamp' is 'None' and 'HEAD' revisions be used
+                if commit_timestamp:
+                    repo.revert_commit_by_time(commit_timestamp)
+                    repo.checkout()
 
     def save_repo_states(self, sources_file, trigger):
         """


### PR DESCRIPTION
- the error checking of "--changed-repo" and "--repo-states" parameters is removed
- new warning messages are added
- new comments are added
- the 'copy' stage is updated