### PR TITLE
Added deploying infrastructure from release branches

### DIFF
--- a/bb/master/config.py
+++ b/bb/master/config.py
@@ -154,7 +154,8 @@ WORKERS = {
         "b-1-14": {}
     },
     "centos_defconfig": {
-        "b-1-20": {},
+        # Workaroud for running 'trigger' builder in parallel with build
+        "b-1-20": {'max_builds': 2},
     },
     "ubuntu": {
         "b-1-18": {},

--- a/bb/master/master.cfg
+++ b/bb/master/master.cfg
@@ -34,7 +34,6 @@ sys.path.append(str(pathlib.Path(__file__).resolve().parents[2]))
 import config
 
 from common import mediasdk_directories
-from common.helper import is_comitter_the_org_member
 
 
 class Stage(Enum):
@@ -220,7 +219,7 @@ for worker_ in config.WORKERS.values():
         ALL_WORKERS_NAMES.append(w_name)
         c["workers"].append(worker.Worker(w_name, config.WORKER_PASS,
                                           properties=prop,
-                                          max_builds=1))  # To disable parallel builds on one worker
+                                          max_builds=prop.get('max_builds') or 1))  # To disable parallel builds on one worker
 
 # Basic config
 c["protocols"] = {"pb": {"port": config.WORKER_PORT}}
@@ -279,7 +278,7 @@ c["services"] = [
 c["change_source"] = []
 
 REPOSITORIES = [
-    {'name': config.MEDIASDK_REPO,
+    {'name': config.GITHUB_OWNERS_REPO,
      # All pull request
      'pull_request_filter': lambda x: True},
     {'name': config.PRODUCT_CONFIGS_REPO,

--- a/bb/master/master.cfg
+++ b/bb/master/master.cfg
@@ -21,6 +21,8 @@
 import time
 import sys
 import pathlib
+import ssl
+import urllib.request
 from enum import Enum
 
 from buildbot.changes.gitpoller import GitPoller
@@ -31,6 +33,8 @@ from twisted.internet import defer
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[2]))
 import config
 
+from common.helper import mediasdk_directories
+
 
 class Stage(Enum):
     CLEAN = "clean"
@@ -40,6 +44,10 @@ class Stage(Enum):
     PACK = "pack"
     COPY = "copy"
 
+def get_repository_name_by_url(repo_url):
+    # Some magic for getting repository name from url, by example
+    #  https://github.com/Intel-Media-SDK/product-configs.git -> product-configs
+    return repo_url.split('/')[-1][:-4]
 
 @util.renderer
 @defer.inlineCallbacks
@@ -47,15 +55,15 @@ def get_infrastructure_deploying_cmd(props):
     infrastructure_deploying_cmd = [
         config.RUN_COMMAND, 'extract_repo.py',
         '--repo-name', 'OPEN_SOURCE_INFRA',
-        '--root-dir', props.getProperty("builddir"),
-        '--branch', props.getProperty("branch")
-    ]
+        '--root-dir', props.getProperty("builddir")]
 
     # Changes in product configs from Intel-Media-SDK/product-configs only will be deployed
     # Infrastructure for changes from any forks or Intel-Media-SDK/MediaSDK repository
     # will be deployed from master branch of Intel-Media-SDK/product-configs repository
-    if props.getProperty('repository') == config.PRODUCT_CONFIGS_REPO_URL:
-        infrastructure_deploying_cmd += ['--commit-id', props.getProperty("revision")]
+    if get_repository_name_by_url(props.getProperty('repository')) == config.PRODUCT_CONFIGS_REPO:
+        infrastructure_deploying_cmd += ['--commit-id', props.getProperty("revision"),
+                                         '--branch', props.getProperty("branch")]
+
     else:
         build_id = props.build.buildid
         sourcestamps = yield props.build.master.db.sourcestamps.getSourceStampsForBuild(build_id)
@@ -63,7 +71,10 @@ def get_infrastructure_deploying_cmd(props):
         formatted_sourcestamp_created_time = time.strftime('%Y-%m-%d %H:%M:%S',
                                                            time.localtime(
                                                                sourcestamps_created_time))
-        infrastructure_deploying_cmd += ['--commit-time', formatted_sourcestamp_created_time]
+        infrastructure_deploying_cmd += ['--commit-time', formatted_sourcestamp_created_time,
+                                         # Set 'branch' value if 'target_branch' property not set
+                                         '--branch',
+                                         util.Interpolate('%(prop:target_branch:-%(prop:branch)s)s')]
 
     defer.returnValue(infrastructure_deploying_cmd)
 
@@ -79,6 +90,38 @@ def get_changed_repo(props):
     return f"{repo_name}:{branch}:{revision}"
 
 
+class StepsGenerator(steps.BuildStep):
+    """
+    Add static steps dynamically in runtime
+    Needed for changing steps depending on the builder properties and commit information
+    """
+
+    def __init__(self, default_factory, build_specification, **kwargs):
+        steps.BuildStep.__init__(self, **kwargs)
+        self.name = 'Generate steps'
+        self.default_factory = default_factory
+        self.build_specification = build_specification
+
+    @defer.inlineCallbacks
+    def run(self):
+        builder_steps = self.default_factory(self.build_specification, self.build.properties)
+        self.build.addStepsAfterCurrentStep(builder_steps)
+
+        # generator is used, because logs adding may take long time
+        yield self.addCompleteLog('list of steps',
+                                  str('\n'.join([str(step) for step in builder_steps])))
+        defer.returnValue(util.SUCCESS)
+
+
+def dynamic_factory(default_factory, build_specification):
+    factory = util.BuildFactory()
+    # Hide debug information about build steps for production mode
+    factory.addStep(StepsGenerator(default_factory=default_factory,
+                                   build_specification=build_specification,
+                                   hideStepIf=config.CURRENT_MODE == config.Mode.PRODUCTION_MODE))
+    return factory
+
+
 def init_trigger_factory():
     trigger_factory = util.BuildFactory()
     trigger_factory.addStep(
@@ -89,15 +132,13 @@ def init_trigger_factory():
 
 
 def factory_with_deploying_infrastructure_step():
-    factory = util.BuildFactory()
-    factory.addStep(
-        steps.ShellCommand(name='deploying infrastructure',
-                           command=get_infrastructure_deploying_cmd,
-                           workdir=r'../common'))
+    factory = [steps.ShellCommand(name='deploying infrastructure',
+                                  command=get_infrastructure_deploying_cmd,
+                                  workdir=r'../common')]
     return factory
 
 
-def init_build_factory(build_specification):
+def init_build_factory(build_specification, props):
     conf_file = build_specification["product_conf_file"]
     product_type = build_specification["product_type"]
     build_type = build_specification["build_type"]
@@ -106,32 +147,33 @@ def init_build_factory(build_specification):
     compiler = build_specification["compiler"]
     compiler_version = build_specification["compiler_version"]
     build_factory = factory_with_deploying_infrastructure_step() if config.DEPLOYING_INFRASTRUCTURE \
-        else util.BuildFactory()
+        else []
+
+    shell_commands = [config.RUN_COMMAND,
+                      "build_runner.py",
+                      "--build-config",
+                      util.Interpolate(r"%(prop:builddir)s/product-configs/%(kw:conf_file)s",
+                                       conf_file=conf_file),
+                      "--root-dir", util.Interpolate(r"%(prop:builddir)s/build_dir"),
+                      "--changed-repo", get_changed_repo,
+                      "--build-type", build_type,
+                      "--build-event", "commit",
+                      "--product-type", product_type,
+                      "--repo-url", util.Interpolate(r"%(prop:repository)s"),
+                      f"compiler={compiler}",
+                      f"compiler_version={compiler_version}",
+                      ]
+    if api_latest:
+        shell_commands.append("api_latest=True")
+    if fastboot:
+        shell_commands.append("fastboot=True")
+    if props.hasProperty('target_branch'):
+        shell_commands += ['--target-branch', props['target_branch']]
 
     # Build by stages: clean, extract, build, install, pack, copy
     for stage in Stage:
-        shell_commands = [config.RUN_COMMAND,
-                          "build_runner.py",
-                          "--build-config",
-                          util.Interpolate(r"%(prop:builddir)s/product-configs/%(kw:conf_file)s",
-                                           conf_file=conf_file),
-                          "--root-dir", util.Interpolate(r"%(prop:builddir)s/build_dir"),
-                          "--changed-repo", get_changed_repo,
-                          "--build-type", build_type,
-                          "--build-event", "commit",
-                          "--product-type", product_type,
-                          "--repo-url", util.Interpolate(r"%(prop:repository)s"),
-                          "--stage", stage.value,
-                          f"compiler={compiler}",
-                          f"compiler_version={compiler_version}",
-                          ]
-        if api_latest:
-            shell_commands.append("api_latest=True")
-        if fastboot:
-            shell_commands.append("fastboot=True")
-
-        build_factory.addStep(
-            steps.ShellCommand(command=shell_commands,
+        build_factory.append(
+            steps.ShellCommand(command=shell_commands+["--stage", stage.value],
                                workdir=r"infrastructure/build_scripts",
                                name=stage.value))
 
@@ -140,19 +182,19 @@ def init_build_factory(build_specification):
     # Currently they will be triggered only for `build-master-branch`, `build`, `build-api-next`
     for test_specification in config.TESTERS:
         if product_type == test_specification["product_type"]:
-            build_factory.addStep(steps.Trigger(schedulerNames=[test_specification["name"]],
+            build_factory.append(steps.Trigger(schedulerNames=[test_specification["name"]],
                                                 waitForFinish=False,
                                                 updateSourceStamp=True))
     return build_factory
 
 
-def init_test_factory(test_specification):
+def init_test_factory(test_specification, props):
     product_type = test_specification["product_type"]
     build_type = test_specification["build_type"]
     test_factory = factory_with_deploying_infrastructure_step() if config.DEPLOYING_INFRASTRUCTURE \
-        else util.BuildFactory()
+        else []
 
-    test_factory.addStep(
+    test_factory.append(
         steps.ShellCommand(command=[config.RUN_COMMAND,
                                     "test_adapter.py",
                                     "--branch", util.Interpolate(r"%(prop:branch)s"),
@@ -204,7 +246,7 @@ for build_specification in config.BUILDERS:
                                                   builderNames=[build_specification["name"]]))
     c["builders"].append(util.BuilderConfig(name=build_specification["name"],
                                             workernames=get_workers(build_specification["worker"]),
-                                            factory=init_build_factory(build_specification)))
+                                            factory=dynamic_factory(init_build_factory, build_specification)))
 
 # Create schedulers and builders for tests
 for test_specification in config.TESTERS:
@@ -212,7 +254,7 @@ for test_specification in config.TESTERS:
                                                   builderNames=[test_specification["name"]]))
     c["builders"].append(util.BuilderConfig(name=test_specification["name"],
                                             workernames=get_workers(test_specification["worker"]),
-                                            factory=init_test_factory(test_specification)))
+                                            factory=dynamic_factory(init_test_factory, test_specification)))
 
 # Push status of build to the Github
 c["services"] = [
@@ -232,45 +274,62 @@ c["services"] = [
 c["change_source"] = []
 
 
-def pull_request_filter(pull_request_message):
-    # Include only changes from fork repositories
-    if pull_request_message["head"]["repo"] and pull_request_message["head"]["repo"][
-        "full_name"] == config.GITHUB_REPOSITORY:
+def is_msdk_org_member(pull_request_message):
+    commit_owner = pull_request_message['head']['user']['login']
+    github_member_url = f"https://api.github.com/orgs/Intel-Media-SDK/members/{commit_owner}?access_token={config.GITHUB_TOKEN}"
+
+    try:
+        response = urllib.request.urlopen(github_member_url,
+                                          context=ssl._create_unverified_context())
+    except Exception as error:
+        print(
+            f"Check organization member: Exception occurred while checking user {commit_owner} in MediaSDK organization: {error}")
         return False
-    return True
+
+    if response.code == 204:
+        return True
+    print(
+        f"Check organization member: user {commit_owner} was not found in MediaSDK organization. Code: {response.code}")
+    return False
 
 
-# To process only the changes from forked MediaSDK repositories
-c["change_source"].append(GitHubPullrequestPoller(
-    owner=config.GITHUB_OWNER,
-    repo=config.GITHUB_OWNERS_REPO,
-    token=config.GITHUB_TOKEN,
-    pullrequest_filter=pull_request_filter,
-    category="mediasdk",
-    pollInterval=config.POLL_INTERVAL,  # Interval of PR`s checking
-    pollAtLaunch=True))
+def is_release_branch(raw_branch):
+    # ignore pull request branches 'refs/pull/'
+    if raw_branch.startswith('refs/heads/'):
+        branch = raw_branch[11:]
+        if mediasdk_directories.MediaSdkDirectories.is_release_branch(branch) or branch == 'master':
+            return True
+    return False
 
-# To process changes from Intel-Media-SDK/MediaSDK repository
-c["change_source"].append(GitPoller(
-    repourl=f"{config.REPO_URL}.git",
-    # Directory for the output of git remote-ls command
-    # WARNING: Changing workdir may cause incorrect work of git poller
-    workdir="gitpoller-workdir",
-    # Poll all branches
-    branches=True,
-    category="mediasdk",
-    pollInterval=config.POLL_INTERVAL,
-    pollAtLaunch=True))
 
-# To process changes from Intel-Media-SDK/product-configs repository
-c["change_source"].append(GitPoller(
-    repourl=config.PRODUCT_CONFIGS_REPO_URL,
-    workdir=f"gitpoller-{config.PRODUCT_CONFIGS_REPO}",
-    # Poll all branches
-    branches=True,
-    category="mediasdk",
-    pollInterval=config.POLL_INTERVAL,
-    pollAtLaunch=True))
+REPOSITORIES = [{'name': config.MEDIASDK_REPO,
+                 # All pull request
+                 'pull_request_filter': lambda x: True},
+                {'name': config.PRODUCT_CONFIGS_REPO,
+                 # Only for members of Intel-Media-SDK organization
+                 # This filter is needed for security, because via product configs can do everything
+                 'pull_request_filter': is_msdk_org_member}]
+
+for repo in REPOSITORIES:
+    repo_url = f"https://github.com/{config.GITHUB_OWNER}/{repo['name']}.git"
+
+    c["change_source"].append(GitPoller(
+        repourl=repo_url,
+        workdir=f"gitpoller-{repo['name']}",  # Dir for the output of git remote-ls command
+        # Poll master and release branches only
+        branches=is_release_branch,
+        category="mediasdk",
+        pollInterval=config.POLL_INTERVAL,
+        pollAtLaunch=True))
+
+    c["change_source"].append(GitHubPullrequestPoller(
+        owner=config.GITHUB_OWNER,
+        repo=repo['name'],
+        token=config.GITHUB_TOKEN,
+        pullrequest_filter=repo['pull_request_filter'],
+        category="mediasdk",
+        pollInterval=config.POLL_INTERVAL,  # Interval of PR`s checking
+        pollAtLaunch=True))
 
 # Web Interface
 c["www"] = dict(port=int(config.PORT),

--- a/bb/master/master.cfg
+++ b/bb/master/master.cfg
@@ -33,7 +33,8 @@ from twisted.internet import defer
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[2]))
 import config
 
-from common.helper import mediasdk_directories
+from common import mediasdk_directories
+from common.helper import is_comitter_the_org_member
 
 
 class Stage(Enum):
@@ -44,10 +45,12 @@ class Stage(Enum):
     PACK = "pack"
     COPY = "copy"
 
+
 def get_repository_name_by_url(repo_url):
-    # Some magic for getting repository name from url, by example
+    # Some magic for getting repository name from GitHub url, by example
     #  https://github.com/Intel-Media-SDK/product-configs.git -> product-configs
     return repo_url.split('/')[-1][:-4]
+
 
 @util.renderer
 @defer.inlineCallbacks
@@ -57,9 +60,9 @@ def get_infrastructure_deploying_cmd(props):
         '--repo-name', 'OPEN_SOURCE_INFRA',
         '--root-dir', props.getProperty("builddir")]
 
-    # Changes in product configs from Intel-Media-SDK/product-configs only will be deployed
-    # Infrastructure for changes from any forks or Intel-Media-SDK/MediaSDK repository
-    # will be deployed from master branch of Intel-Media-SDK/product-configs repository
+    # Changes from product-configs\fork of product configs repositories will be deployed as is.
+    # Infrastructure for changes from other repos will be extracted from master\release branch of
+    # Intel-Media-SDK/product-configs repository.
     if get_repository_name_by_url(props.getProperty('repository')) == config.PRODUCT_CONFIGS_REPO:
         infrastructure_deploying_cmd += ['--commit-id', props.getProperty("revision"),
                                          '--branch', props.getProperty("branch")]
@@ -72,9 +75,10 @@ def get_infrastructure_deploying_cmd(props):
                                                            time.localtime(
                                                                sourcestamps_created_time))
         infrastructure_deploying_cmd += ['--commit-time', formatted_sourcestamp_created_time,
-                                         # Set 'branch' value if 'target_branch' property not set
+                                         # Set 'branch' value if 'target_branch' property not set.
                                          '--branch',
-                                         util.Interpolate('%(prop:target_branch:-%(prop:branch)s)s')]
+                                         util.Interpolate(
+                                             '%(prop:target_branch:-%(prop:branch)s)s')]
 
     defer.returnValue(infrastructure_deploying_cmd)
 
@@ -92,8 +96,7 @@ def get_changed_repo(props):
 
 class StepsGenerator(steps.BuildStep):
     """
-    Add static steps dynamically in runtime
-    Needed for changing steps depending on the builder properties and commit information
+    Add steps in run-time [dynamically] based on the builder properties and commit information
     """
 
     def __init__(self, default_factory, build_specification, **kwargs):
@@ -173,7 +176,7 @@ def init_build_factory(build_specification, props):
     # Build by stages: clean, extract, build, install, pack, copy
     for stage in Stage:
         build_factory.append(
-            steps.ShellCommand(command=shell_commands+["--stage", stage.value],
+            steps.ShellCommand(command=shell_commands + ["--stage", stage.value],
                                workdir=r"infrastructure/build_scripts",
                                name=stage.value))
 
@@ -183,8 +186,8 @@ def init_build_factory(build_specification, props):
     for test_specification in config.TESTERS:
         if product_type == test_specification["product_type"]:
             build_factory.append(steps.Trigger(schedulerNames=[test_specification["name"]],
-                                                waitForFinish=False,
-                                                updateSourceStamp=True))
+                                               waitForFinish=False,
+                                               updateSourceStamp=True))
     return build_factory
 
 
@@ -246,7 +249,8 @@ for build_specification in config.BUILDERS:
                                                   builderNames=[build_specification["name"]]))
     c["builders"].append(util.BuilderConfig(name=build_specification["name"],
                                             workernames=get_workers(build_specification["worker"]),
-                                            factory=dynamic_factory(init_build_factory, build_specification)))
+                                            factory=dynamic_factory(init_build_factory,
+                                                                    build_specification)))
 
 # Create schedulers and builders for tests
 for test_specification in config.TESTERS:
@@ -254,7 +258,8 @@ for test_specification in config.TESTERS:
                                                   builderNames=[test_specification["name"]]))
     c["builders"].append(util.BuilderConfig(name=test_specification["name"],
                                             workernames=get_workers(test_specification["worker"]),
-                                            factory=dynamic_factory(init_test_factory, test_specification)))
+                                            factory=dynamic_factory(init_test_factory,
+                                                                    test_specification)))
 
 # Push status of build to the Github
 c["services"] = [
@@ -273,42 +278,17 @@ c["services"] = [
 # Get changes
 c["change_source"] = []
 
-
-def is_msdk_org_member(pull_request_message):
-    commit_owner = pull_request_message['head']['user']['login']
-    github_member_url = f"https://api.github.com/orgs/Intel-Media-SDK/members/{commit_owner}?access_token={config.GITHUB_TOKEN}"
-
-    try:
-        response = urllib.request.urlopen(github_member_url,
-                                          context=ssl._create_unverified_context())
-    except Exception as error:
-        print(
-            f"Check organization member: Exception occurred while checking user {commit_owner} in MediaSDK organization: {error}")
-        return False
-
-    if response.code == 204:
-        return True
-    print(
-        f"Check organization member: user {commit_owner} was not found in MediaSDK organization. Code: {response.code}")
-    return False
-
-
-def is_release_branch(raw_branch):
-    # ignore pull request branches 'refs/pull/'
-    if raw_branch.startswith('refs/heads/'):
-        branch = raw_branch[11:]
-        if mediasdk_directories.MediaSdkDirectories.is_release_branch(branch) or branch == 'master':
-            return True
-    return False
-
-
-REPOSITORIES = [{'name': config.MEDIASDK_REPO,
-                 # All pull request
-                 'pull_request_filter': lambda x: True},
-                {'name': config.PRODUCT_CONFIGS_REPO,
-                 # Only for members of Intel-Media-SDK organization
-                 # This filter is needed for security, because via product configs can do everything
-                 'pull_request_filter': is_msdk_org_member}]
+REPOSITORIES = [
+    {'name': config.MEDIASDK_REPO,
+     # All pull request
+     'pull_request_filter': lambda x: True},
+    {'name': config.PRODUCT_CONFIGS_REPO,
+     # Only for members of Intel-Media-SDK organization
+     # This filter is needed for security, because via product configs can do everything
+     'pull_request_filter': mediasdk_directories.is_comitter_the_org_member(
+         organization=config.GITHUB_OWNER,
+         token=config.GITHUB_TOKEN)}
+]
 
 for repo in REPOSITORIES:
     repo_url = f"https://github.com/{config.GITHUB_OWNER}/{repo['name']}.git"
@@ -317,7 +297,7 @@ for repo in REPOSITORIES:
         repourl=repo_url,
         workdir=f"gitpoller-{repo['name']}",  # Dir for the output of git remote-ls command
         # Poll master and release branches only
-        branches=is_release_branch,
+        branches=mediasdk_directories.is_release_branch,
         category="mediasdk",
         pollInterval=config.POLL_INTERVAL,
         pollAtLaunch=True))

--- a/build_scripts/build_runner.py
+++ b/build_scripts/build_runner.py
@@ -333,7 +333,7 @@ class BuildGenerator(object):
 
     def __init__(self, build_config_path, root_dir, build_type, product_type, build_event, stage,
                  commit_time=None, changed_repo=None, repo_states_file_path=None, repo_url=None, target_arch=None,
-                 custom_cli_args=None):
+                 custom_cli_args=None, target_branch=None):
         """
         :param build_config_path: Path to build configuration file
         :type build_config_path: pathlib.Path
@@ -405,6 +405,7 @@ class BuildGenerator(object):
         self.custom_cli_args = custom_cli_args
         self.current_stage = stage
         self.target_arch = target_arch
+        self.target_branch = target_branch
 
         self.log = logging.getLogger(self.__class__.__name__)
 
@@ -637,7 +638,9 @@ class BuildGenerator(object):
                     if self.repo_url:
                         data['url'] = self.repo_url
                 elif not data.get('branch'):
-                    if MediaSdkDirectories.is_release_branch(branch):
+                    if self.target_branch and MediaSdkDirectories.is_release_branch(self.target_branch):
+                        data['branch'] = self.target_branch
+                    elif MediaSdkDirectories.is_release_branch(branch) and not self.target_branch:
                         data['branch'] = branch
         elif self.repo_states:
             for repo_name, values in self.repo_states.items():
@@ -1040,6 +1043,8 @@ which is not present in mediasdk_directories.''')
                         default=[target_arch.value for target_arch in TargetArch],
                         choices=[target_arch.value for target_arch in TargetArch],
                         help='Architecture of target platform')
+    parser.add_argument('-tb', "--target-branch", default=None,
+                        help=f'All not triggered repos will be checkout to this branch.')
 
     parsed_args, unknown_args = parser.parse_known_args()
 
@@ -1078,7 +1083,8 @@ which is not present in mediasdk_directories.''')
         repo_url=parsed_args.repo_url,
         custom_cli_args=custom_cli_args,
         stage=parsed_args.stage,
-        target_arch=target_arch
+        target_arch=target_arch,
+        target_branch=parsed_args.target_branch
     )
 
     # We must create BuildGenerator anyway.

--- a/build_scripts/build_runner.py
+++ b/build_scripts/build_runner.py
@@ -1043,7 +1043,7 @@ which is not present in mediasdk_directories.''')
                         default=[target_arch.value for target_arch in TargetArch],
                         choices=[target_arch.value for target_arch in TargetArch],
                         help='Architecture of target platform')
-    parser.add_argument('-tb', "--target-branch", default=None,
+    parser.add_argument('-tb', "--target-branch",
                         help=f'All not triggered repos will be checkout to this branch.')
 
     parsed_args, unknown_args = parser.parse_known_args()


### PR DESCRIPTION
- Changed pollers strategy - GitPoller works only for release branches,
  GitHubPullRequestPoller works for all pull requests
- Added "target_branch" properties to correct extracting infrastructure\product
  repositories
- Added dynamic factories