### PR TITLE
Fixes for driver tests

### DIFF
--- a/bb/driver/config.py
+++ b/bb/driver/config.py
@@ -58,7 +58,7 @@ BUILDERS = [
 TESTERS = [
     {
         "name": "test",
-        "product_type": Product_type.PUBLIC_LINUX.value,
+        "product_type": Product_type.PUBLIC_LINUX_DRIVER.value,
         "build_type": Build_type.RELEASE.value,
         "worker": "centos_test"
     }
@@ -70,7 +70,7 @@ WORKERS = {
         "b-1-14": {}
     },
     "centos_test": {
-        "b-1-17": {}
+        "t-1-17": {}
     }
 }
 

--- a/bb/driver/master.py
+++ b/bb/driver/master.py
@@ -212,7 +212,7 @@ def init_test_factory(test_specification, props):
                                                              props['revision'],
                                                              test_specification['product_type'],
                                                              test_specification['build_type'],
-                                                             product='driver')
+                                                             product='media-driver')
     command = [config.RUN_COMMAND, "tests_runner.py",
                '--artifacts', str(driver_manifest_path),
                '--root-dir', util.Interpolate('%(prop:builddir)s'),
@@ -220,7 +220,7 @@ def init_test_factory(test_specification, props):
 
     for test_stage in TestStage:
         test_factory.append(
-            steps.ShellCommand(name='test',
+            steps.ShellCommand(name=test_stage.value,
                                command=command+[test_stage.value],
                                workdir=r"infrastructure/build_scripts"))
     return test_factory
@@ -284,7 +284,7 @@ c["services"] = [
                                startDescription="Started",
                                endDescription="Done",
                                verbose=True,
-                               builders=['build'])]
+                               builders=['build', 'test'])]
 
 # Get changes
 c["change_source"] = []

--- a/build_scripts/tests_runner.py
+++ b/build_scripts/tests_runner.py
@@ -126,6 +126,7 @@ class TestRunner(ConfigGenerator):
         self._log.info("COPYING")
 
         # TODO: Save results on share
+        return True
 
 
 def main():


### PR DESCRIPTION
- Changed worker name and names of test stages.
- Specified correct product type and component name.
- Added notifications for tests.
- Added return from copy stage in test scripts, because this stage failed without it.