### PR TITLE
Add method for creating config file

### DIFF
--- a/build_scripts/build_runner.py
+++ b/build_scripts/build_runner.py
@@ -50,7 +50,7 @@ from tenacity import retry, stop_after_attempt, wait_exponential
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 from build_scripts.common_runner import ConfigGenerator, Action, RunnerException
 from common.helper import Stage, Product_type, Build_event, Build_type, make_archive, \
-    copy_win_files, rotate_dir, cmd_exec, copytree, get_packing_cmd, ErrorCode, TargetArch, extract_archive
+    copy_win_files, rotate_dir, cmd_exec, copytree, get_packing_cmd, ErrorCode, TargetArch, extract_archive, create_file
 
 from common.logger_conf import configure_logger
 from common.git_worker import ProductState
@@ -330,6 +330,7 @@ class BuildGenerator(ConfigGenerator):
             'get_packing_cmd': get_packing_cmd,
             'get_commit_number': ProductState.get_commit_number,
             'copytree': copytree,
+            'create_config_file': create_file,
         })
 
     def _get_config_vars(self):

--- a/common/helper.py
+++ b/common/helper.py
@@ -660,3 +660,14 @@ def get_packing_cmd(pack_type, pack_dir, enable_ruby, version, source_name):
     if int(major_version) < 7:
         return f'{enable_ruby} && {command}'
     return command
+
+
+def create_file(config: dict):
+    """
+    Create file(s) according config
+    :param config: dict = {directory: 'data to write'}
+    """
+    for file_path, data in config.items():
+        with pathlib.Path(file_path).open('w') as fw:
+            fw.write(data)
+


### PR DESCRIPTION
Expanded build api with ability to create configuration files and add them to rpm/deb packages.
It is needed for resolving dependencies while installing rpm/deb packages.