### PR TITLE
Fix build_runner for HEAD revision build

### DIFF
--- a/build_scripts/build_runner.py
+++ b/build_scripts/build_runner.py
@@ -308,6 +308,7 @@ class BuildGenerator(ConfigGenerator):
                 raise Exception(f'{repo_states_file} does not exist')
         else:
             self.branch_name = 'master'
+            self.changed_repo_name = None
 
     def _update_global_vars(self):
         self._global_vars.update({


### PR DESCRIPTION
The 'BuildGenerator.changed_repo_name' class field will be setup 'None' if the 'changed_repo' CLI parameter is not set. This helps to avoid the 'BuildGenerator._global_vars.update' method fall.