### PR TITLE
Disable mandatory decoding with utf-8

### DIFF
--- a/common/helper.py
+++ b/common/helper.py
@@ -649,7 +649,6 @@ def cmd_exec(cmd, env=None, cwd=None, shell=True, log=None, verbose=True, hide=N
                                            check=True,
                                            stdout=subprocess.PIPE,
                                            stderr=subprocess.STDOUT,
-                                           encoding='utf-8',
                                            errors='backslashreplace')
 
         return completed_process.returncode, completed_process.stdout


### PR DESCRIPTION
Gives ability to use utf-16 without the errors, for example in case of using powershell.