### PR TITLE
[Buildbot] Temporary disable event for one_ci_dev branch

### DIFF
--- a/bb/driver/master.py
+++ b/bb/driver/master.py
@@ -100,6 +100,10 @@ class ProductConfigsChecker(ChangeChecker):
         return None
 
     def pull_request_filter(self, pull_request, files):
+        # For commits in one_ci_dev branch will be enabled prototype of One CI buildbot configuration,
+        # so disable event this branch in all production Buildbots services.
+        if pull_request['base']['ref'] == 'one_ci_dev':
+            return None
         if any([file for file in files if file.startswith('driver/') or file == 'infrastructure_version.py']):
             return self.default_properties
         return None

--- a/bb/master/master.py
+++ b/bb/master/master.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018 Intel Corporation
+# Copyright (c) 2019 Intel Corporation
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/bb/master/master.py
+++ b/bb/master/master.py
@@ -91,8 +91,12 @@ c["change_source"] = []
 
 
 class MediasdkChangeChecker(bb.utils.ChangeChecker):
-    # No filtration
     def pull_request_filter(self, pull_request, files):
+        # For commits in one_ci_dev branch will be enabled prototype of One CI buildbot configuration,
+        # so disable event this branch in all production Buildbots services.
+        # WARNING: this branch also disabled for MediaSDK
+        if pull_request['base']['ref'] == 'one_ci_dev':
+            return None
         return self.default_properties
 
 

--- a/bb/utils.py
+++ b/bb/utils.py
@@ -177,6 +177,13 @@ class ChangeChecker:
         By default checks membership of committer in organization.
         :return None if change is not needed or dict with properties otherwise
         """
+
+        # For commits in one_ci_dev branch will be enabled prototype of One CI buildbot configuration,
+        # so disable event this branch in all production Buildbots services.
+
+        if pull_request['base']['ref'] == 'one_ci_dev':
+            return None
+
         is_request_needed = is_comitter_the_org_member(pull_request, self.token)
         if is_request_needed:
             return self.default_properties


### PR DESCRIPTION
- This branch created for development One CI.
  Production CI can not work correctly for this branch because
    all script will be redesigned in it.