### PR TITLE
[Git worker] Update method

### DIFF
--- a/common/git_worker.py
+++ b/common/git_worker.py
@@ -437,8 +437,8 @@ class ProductState(object):
         if file_path.exists() and not file_path.is_dir():
             repo = git.Repo(str(repo))
             rel_file_path = str(file_path.relative_to(repo.working_dir))
-            blame = repo.blame("HEAD", rel_file_path, L=f'{line},+1', e=True)
             try:
+                blame = repo.blame("HEAD", rel_file_path, L=f'{line},+1', e=True)
                 return blame[0][0].author.email
             except Exception:
                 pass


### PR DESCRIPTION
Git blame throws exception if file was generated while building
(it does not exist in commit)