### PR TITLE
[One CI][Runners] New behavior for build and manifest runners

### DIFF
--- a/build_scripts/build_runner.py
+++ b/build_scripts/build_runner.py
@@ -285,7 +285,7 @@ class BuildGenerator(ConfigGenerator):
             'get_build_number': get_build_number,
             'get_api_version': self._get_api_version,
             'branch_name': self._component.trigger_repository.branch,
-            'changed_repo_name': self._component.trigger_repository.name,
+            'changed_repo_name': self._manifest.event_repo.name,
             'update_config': self._update_config,
             'target_arch': self._target_arch,
             'get_packing_cmd': get_packing_cmd,

--- a/build_scripts/build_runner.py
+++ b/build_scripts/build_runner.py
@@ -260,6 +260,7 @@ class BuildGenerator(ConfigGenerator):
             "ENV": {},  # Dictionary of dynamical environment variables
             "STRIP_BINARIES": False,  # Flag for stripping binaries of build
         })
+        self._product_repos = []
         self._dev_pkg_data_to_archive = []
         self._install_pkg_data_to_archive = []
         self._custom_cli_args = custom_cli_args
@@ -293,6 +294,11 @@ class BuildGenerator(ConfigGenerator):
             'manifest': self._manifest,
             'create_file': create_file
         })
+
+    def _get_config_vars(self):
+        if 'PRODUCT_REPOS' in self._config_variables:
+            for repo in self._config_variables['PRODUCT_REPOS']:
+                self._product_repos.append(repo['name'])
 
     def _action(self, name, stage=None, cmd=None, work_dir=None, env=None, callfunc=None, verbose=False):
         """
@@ -418,11 +424,12 @@ class BuildGenerator(ConfigGenerator):
 
         repo_states = collections.defaultdict(dict)
         for repo in self._component.repositories:
-            repo_states[repo.name]['target_branch'] = repo.target_branch
-            repo_states[repo.name]['branch'] = repo.branch
-            repo_states[repo.name]['commit_id'] = repo.revision
-            repo_states[repo.name]['url'] = repo.url
-            repo_states[repo.name]['trigger'] = repo.name == self._component.build_info.trigger
+            if not self._product_repos or repo.name in self._product_repos:
+                repo_states[repo.name]['target_branch'] = repo.target_branch
+                repo_states[repo.name]['branch'] = repo.branch
+                repo_states[repo.name]['commit_id'] = repo.revision
+                repo_states[repo.name]['url'] = repo.url
+                repo_states[repo.name]['trigger'] = repo.name == self._component.build_info.trigger
 
         product_state = ProductState(repo_states, self._options["REPOS_DIR"])
 

--- a/build_scripts/build_runner.py
+++ b/build_scripts/build_runner.py
@@ -785,9 +785,11 @@ class BuildGenerator(ConfigGenerator):
                 if comp:
                     try:
                         dep_dir = get_build_dir(self._manifest, dependency)
-                        self._log.info(f'Extracting {dependency} {comp.build_info.product_type} artifacts')
                         # TODO: Extension hardcoded for open source. Need to use only .zip in future.
-                        extract_archive(dep_dir / f'install_pkg.tar.gz', deps_dir / dependency)
+                        dep_pkg = dep_dir / f'install_pkg.tar.gz'
+
+                        self._log.info(f'Extracting {dep_pkg}')
+                        extract_archive(dep_pkg, deps_dir / dependency)
                     except Exception:
                         self._log.exception('Can not extract archive')
                         return False

--- a/build_scripts/manifest_runner.py
+++ b/build_scripts/manifest_runner.py
@@ -169,6 +169,8 @@ class ManifestRunner:
                 if repo.name == self._repo:
                     component.build_info.set_build_event(self._build_event)
                     component.build_info.set_trigger(repo.name)
+                    self._manifest.set_event_component(component.name)
+                    self._manifest.set_event_repo(repo.name)
 
                 if repo.name in self._updated_repos:
                     upd_repo = Repository(
@@ -187,12 +189,7 @@ class ManifestRunner:
 
         self._log.info('Saving manifest')
 
-        component_name = None
-        for component in self._manifest.components:
-            for repo in component.repositories:
-                if repo.name == self._repo:
-                    component_name = component.name
-
+        component_name = self._manifest.event_component.name
         manifest_path = get_build_dir(self._manifest, component_name, link_type='manifest') / 'manifest.yml'
         manifest_url = get_build_url(self._manifest, component_name, link_type='manifest') + '/manifest.yml'
 

--- a/common/manifest_manager.py
+++ b/common/manifest_manager.py
@@ -69,6 +69,8 @@ class Manifest:
 
         self._manifest_file = pathlib.Path(manifest_path if manifest_path else 'manifest.yml')
         self._version = '0'  # gets from manifest
+        self._event_component = None  # gets from manifest
+        self._event_repo = None  # gets from manifest
         self._components = {}  # gets from manifest
 
         if manifest_path is not None:
@@ -90,6 +92,8 @@ class Manifest:
                 manifest_info = yaml.load(manifest, Loader=yaml.FullLoader)
 
             self._version = manifest_info.get('version', '0')
+            self._event_component = manifest_info['event']['component']
+            self._event_repo = manifest_info['event']['repository']
 
             for name, info in manifest_info['components'].items():
                 self._components[name] = Component.from_dict({
@@ -111,10 +115,44 @@ class Manifest:
     @property
     def components(self):
         """
-            get components list
+        get components list
         """
 
         return list(self._components.values())
+
+    @property
+    def event_component(self):
+        """
+        get event component
+        """
+
+        return self.get_component(self._event_component)
+
+    @property
+    def event_repo(self):
+        """
+        get event repository
+        """
+
+        return self.event_component.get_repository(self._event_repo)
+
+    def set_event_component(self, component):
+        """
+        setter for event component
+
+        :param component: Component name
+        """
+
+        self._event_component = component
+
+    def set_event_repo(self, repo):
+        """
+        setter for event repo
+
+        :param repo: Repository name
+        """
+
+        self._event_repo = repo
 
     def get_component(self, component_name):
         """
@@ -181,6 +219,10 @@ class Manifest:
         path_to_save.parent.mkdir(parents=True, exist_ok=True)
 
         manifest_data = {'components': {},
+                         'event': {
+                             'component': self._event_component,
+                             'repository': self._event_repo
+                         },
                          'version': self._version}
 
         for comp_name, comp_data in self._components.items():


### PR DESCRIPTION
PRODUCT_REPOS list in build configurations can be used for filtering
repositories that will be extracted.