### PR TITLE
[Buildbot] Rename manifest updater

### DIFF
--- a/bb/master/config.py
+++ b/bb/master/config.py
@@ -459,7 +459,7 @@ BUILDERS = {
                           PRODUCTION_REPOS,
                           lambda branch, target_branch: (target_branch or branch) == 'master')}]},
     
-    "manifest-updater": {
+    "update-manifest": {
         "factory": FACTORIES.init_updater_factory,
         "worker": "ubuntu",
         'triggers': [{'filter': GithubCommitFilter(


### PR DESCRIPTION
This change is needed to create separated builder column
(to the right of trigger) which don't violates build\test grouping in UI,
because buildbot automatically group builders by name
Just for increasing usability of Console View